### PR TITLE
Fase 8: Correcciones de calidad pre-release (ruff + mypy)

### DIFF
--- a/src/quality_agents/designreviewer/agent.py
+++ b/src/quality_agents/designreviewer/agent.py
@@ -124,8 +124,8 @@ class DesignReviewer:
 
 # --- CLI --- (imports aquí para evitar importación circular con formatter.py)
 
-import sys
-import time
+import sys  # noqa: E402
+import time  # noqa: E402
 
 import click  # noqa: E402
 

--- a/src/quality_agents/designreviewer/analyzers/__init__.py
+++ b/src/quality_agents/designreviewer/analyzers/__init__.py
@@ -104,16 +104,16 @@ Ticket: 1.1
 # Imports de analyzers implementados
 from .cbo_analyzer import CBOAnalyzer
 from .circular_imports_analyzer import CircularImportsAnalyzer
-from .fan_out_analyzer import FanOutAnalyzer
+from .data_clumps_analyzer import DataClumpsAnalyzer
 from .dit_analyzer import DITAnalyzer
-from .lcom_analyzer import LCOMAnalyzer
-from .nop_analyzer import NOPAnalyzer
-from .wmc_analyzer import WMCAnalyzer
+from .fan_out_analyzer import FanOutAnalyzer
+from .feature_envy_analyzer import FeatureEnvyAnalyzer
 from .god_object_analyzer import GodObjectAnalyzer
+from .lcom_analyzer import LCOMAnalyzer
 from .long_method_analyzer import LongMethodAnalyzer
 from .long_parameter_list_analyzer import LongParameterListAnalyzer
-from .feature_envy_analyzer import FeatureEnvyAnalyzer
-from .data_clumps_analyzer import DataClumpsAnalyzer
+from .nop_analyzer import NOPAnalyzer
+from .wmc_analyzer import WMCAnalyzer
 
 __all__ = [
     "CBOAnalyzer",

--- a/src/quality_agents/designreviewer/analyzers/circular_imports_analyzer.py
+++ b/src/quality_agents/designreviewer/analyzers/circular_imports_analyzer.py
@@ -93,9 +93,9 @@ class CircularImportsAnalyzer(Verifiable):
                     ),
                     file_path=file_path,
                     suggestion=(
-                        f"Romper el ciclo extrayendo las dependencias comunes a un "
-                        f"tercer módulo, o invirtiendo una de las dependencias mediante "
-                        f"una interfaz/protocolo."
+                        "Romper el ciclo extrayendo las dependencias comunes a un "
+                        "tercer módulo, o invirtiendo una de las dependencias mediante "
+                        "una interfaz/protocolo."
                     ),
                     estimated_effort=2.0,
                 ))

--- a/src/quality_agents/designreviewer/analyzers/data_clumps_analyzer.py
+++ b/src/quality_agents/designreviewer/analyzers/data_clumps_analyzer.py
@@ -24,7 +24,7 @@ import ast
 from collections import defaultdict
 from itertools import combinations
 from pathlib import Path
-from typing import Any, Dict, FrozenSet, List, Optional, Set, Tuple
+from typing import Any, Dict, FrozenSet, List, Optional, Set, Tuple, Union
 
 from quality_agents.designreviewer.models import ReviewResult, ReviewSeverity, SolidPrinciple
 from quality_agents.shared.verifiable import ExecutionContext, Verifiable
@@ -154,7 +154,7 @@ class DataClumpsAnalyzer(Verifiable):
                     nombre = f"{class_name}.{nodo.name}" if class_name else nodo.name
                     firmas.append((nombre, frozenset(params)))
 
-    def _obtener_params(self, func_node: ast.FunctionDef) -> List[str]:
+    def _obtener_params(self, func_node: Union[ast.FunctionDef, ast.AsyncFunctionDef]) -> List[str]:
         """
         Retorna los parámetros de la función excluyendo self, cls, *args y **kwargs.
         """

--- a/src/quality_agents/designreviewer/analyzers/feature_envy_analyzer.py
+++ b/src/quality_agents/designreviewer/analyzers/feature_envy_analyzer.py
@@ -22,7 +22,7 @@ Ticket: 4.4
 
 import ast
 from pathlib import Path
-from typing import Any, Dict, List, Set
+from typing import Any, Dict, List, Set, Union
 
 from quality_agents.designreviewer.models import ReviewResult, ReviewSeverity, SolidPrinciple
 from quality_agents.shared.verifiable import ExecutionContext, Verifiable
@@ -150,7 +150,7 @@ class FeatureEnvyAnalyzer(Verifiable):
                     smell_type="FeatureEnvy",
                 ))
 
-    def _obtener_params_externos(self, func_node: ast.FunctionDef) -> List[str]:
+    def _obtener_params_externos(self, func_node: Union[ast.FunctionDef, ast.AsyncFunctionDef]) -> List[str]:
         """
         Retorna los nombres de parámetros de la función excluyendo self y cls.
 
@@ -161,7 +161,7 @@ class FeatureEnvyAnalyzer(Verifiable):
         todos = list(args.posonlyargs) + list(args.args) + list(args.kwonlyargs)
         return [a.arg for a in todos if a.arg not in _PARAMS_IMPLICITOS]
 
-    def _contar_accesos(self, func_node: ast.FunctionDef, nombre: str) -> int:
+    def _contar_accesos(self, func_node: Union[ast.FunctionDef, ast.AsyncFunctionDef], nombre: str) -> int:
         """
         Cuenta las ocurrencias de `nombre.algo` en el cuerpo del método.
 

--- a/src/quality_agents/designreviewer/analyzers/god_object_analyzer.py
+++ b/src/quality_agents/designreviewer/analyzers/god_object_analyzer.py
@@ -83,7 +83,7 @@ class GodObjectAnalyzer(Verifiable):
                 continue
 
             n_metodos = self._contar_metodos_publicos(node)
-            n_lineas = node.end_lineno - node.lineno + 1  # type: ignore[attr-defined]
+            n_lineas = (node.end_lineno or node.lineno) - node.lineno + 1
 
             excede_metodos = n_metodos > max_methods
             excede_lineas = n_lineas > max_lines

--- a/src/quality_agents/designreviewer/analyzers/lcom_analyzer.py
+++ b/src/quality_agents/designreviewer/analyzers/lcom_analyzer.py
@@ -15,7 +15,7 @@ Ticket: 3.1 + 3.5
 
 import ast
 from pathlib import Path
-from typing import Any, Dict, List, Set
+from typing import Any, Dict, List, Set, Union
 
 from quality_agents.designreviewer.models import ReviewResult, ReviewSeverity
 from quality_agents.shared.verifiable import ExecutionContext, Verifiable
@@ -144,7 +144,7 @@ class LCOMAnalyzer(Verifiable):
 
         return self._contar_componentes(atributos_por_metodo)
 
-    def _es_no_instancia(self, func_node: ast.FunctionDef) -> bool:
+    def _es_no_instancia(self, func_node: Union[ast.FunctionDef, ast.AsyncFunctionDef]) -> bool:
         """Retorna True si el método es estático, de clase o abstracto sin cuerpo real."""
         for decorador in func_node.decorator_list:
             nombre = None
@@ -156,7 +156,7 @@ class LCOMAnalyzer(Verifiable):
                 return True
         return False
 
-    def _atributos_de_instancia(self, func_node: ast.FunctionDef) -> Set[str]:
+    def _atributos_de_instancia(self, func_node: Union[ast.FunctionDef, ast.AsyncFunctionDef]) -> Set[str]:
         """
         Extrae el conjunto de nombres de atributos de instancia (self.X) accedidos
         en el cuerpo del método.

--- a/src/quality_agents/designreviewer/analyzers/long_method_analyzer.py
+++ b/src/quality_agents/designreviewer/analyzers/long_method_analyzer.py
@@ -13,7 +13,7 @@ Ticket: 4.2
 
 import ast
 from pathlib import Path
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Union
 
 from quality_agents.designreviewer.models import ReviewResult, ReviewSeverity, SolidPrinciple
 from quality_agents.shared.verifiable import ExecutionContext, Verifiable
@@ -107,14 +107,14 @@ class LongMethodAnalyzer(Verifiable):
 
     def _evaluar_funcion(
         self,
-        func: ast.FunctionDef,
+        func: Union[ast.FunctionDef, ast.AsyncFunctionDef],
         file_path: Path,
         threshold: int,
         results: List[ReviewResult],
         class_name: Optional[str],
     ) -> None:
         """Evalúa una función y agrega un resultado si supera el umbral."""
-        lineas = func.end_lineno - func.lineno + 1  # type: ignore[attr-defined]
+        lineas = (func.end_lineno or func.lineno) - func.lineno + 1
         if lineas <= threshold:
             return
 

--- a/src/quality_agents/designreviewer/analyzers/long_parameter_list_analyzer.py
+++ b/src/quality_agents/designreviewer/analyzers/long_parameter_list_analyzer.py
@@ -15,7 +15,7 @@ Ticket: 4.3
 
 import ast
 from pathlib import Path
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Union
 
 from quality_agents.designreviewer.models import ReviewResult, ReviewSeverity, SolidPrinciple
 from quality_agents.shared.verifiable import ExecutionContext, Verifiable
@@ -110,7 +110,7 @@ class LongParameterListAnalyzer(Verifiable):
 
     def _evaluar_funcion(
         self,
-        func: ast.FunctionDef,
+        func: Union[ast.FunctionDef, ast.AsyncFunctionDef],
         file_path: Path,
         threshold: int,
         results: List[ReviewResult],
@@ -144,7 +144,7 @@ class LongParameterListAnalyzer(Verifiable):
             smell_type="LongParameterList",
         ))
 
-    def _contar_parametros(self, func: ast.FunctionDef) -> int:
+    def _contar_parametros(self, func: Union[ast.FunctionDef, ast.AsyncFunctionDef]) -> int:
         """
         Cuenta los parámetros explícitos de la función, excluyendo self/cls, *args y **kwargs.
 

--- a/src/quality_agents/designreviewer/analyzers/wmc_analyzer.py
+++ b/src/quality_agents/designreviewer/analyzers/wmc_analyzer.py
@@ -18,8 +18,8 @@ from quality_agents.designreviewer.models import ReviewResult, ReviewSeverity
 from quality_agents.shared.verifiable import ExecutionContext, Verifiable
 
 try:
-    from radon.complexity import cc_visit
-    from radon.visitors import Class as RadonClass
+    from radon.complexity import cc_visit  # type: ignore[import-untyped]
+    from radon.visitors import Class as RadonClass  # type: ignore[import-untyped]
 
     _RADON_DISPONIBLE = True
 except ImportError:

--- a/src/quality_agents/designreviewer/formatter.py
+++ b/src/quality_agents/designreviewer/formatter.py
@@ -213,9 +213,9 @@ def _print_effort_summary(console: Console, results: List[ReviewResult]) -> None
 
     effort_text = Text()
     effort_text.append("Esfuerzo estimado de refactoring:\n", style="bold")
-    effort_text.append(f"  Blocking issues: ", style="red")
+    effort_text.append("  Blocking issues: ", style="red")
     effort_text.append(f"{critical_effort:.1f}h\n", style="bold red")
-    effort_text.append(f"  Total del changeset: ", style="cyan")
+    effort_text.append("  Total del changeset: ", style="cyan")
     effort_text.append(f"{total_effort:.1f}h", style="bold cyan")
 
     console.print()

--- a/tests/e2e/test_designreviewer_e2e.py
+++ b/tests/e2e/test_designreviewer_e2e.py
@@ -13,7 +13,6 @@ Fecha: 2026-02-21
 """
 
 import json
-import tempfile
 from pathlib import Path
 from textwrap import dedent
 
@@ -21,8 +20,6 @@ import pytest
 from click.testing import CliRunner
 
 from quality_agents.designreviewer.agent import main
-from quality_agents.designreviewer.models import ReviewSeverity
-
 
 # ---------------------------------------------------------------------------
 # Fixtures de código sintético con violaciones conocidas

--- a/tests/integration/test_designreviewer_cli.py
+++ b/tests/integration/test_designreviewer_cli.py
@@ -21,7 +21,6 @@ from click.testing import CliRunner
 from quality_agents.designreviewer.agent import main
 from quality_agents.designreviewer.models import ReviewResult, ReviewSeverity
 
-
 # --- Fixtures ---
 
 PYTHON_LIMPIO = "# Archivo sin problemas\ndef suma(a, b):\n    return a + b\n"

--- a/tests/unit/test_designreviewer_analyzers_acoplamiento.py
+++ b/tests/unit/test_designreviewer_analyzers_acoplamiento.py
@@ -10,8 +10,6 @@ Ticket: 2.5
 import textwrap
 from pathlib import Path
 
-import pytest
-
 from quality_agents.designreviewer.analyzers.cbo_analyzer import CBOAnalyzer
 from quality_agents.designreviewer.analyzers.circular_imports_analyzer import (
     CircularImportsAnalyzer,
@@ -21,7 +19,6 @@ from quality_agents.designreviewer.config import DesignReviewerConfig
 from quality_agents.designreviewer.models import ReviewResult, ReviewSeverity
 from quality_agents.designreviewer.orchestrator import AnalyzerOrchestrator
 from quality_agents.shared.verifiable import ExecutionContext
-
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Helpers

--- a/tests/unit/test_designreviewer_analyzers_cohesion_herencia.py
+++ b/tests/unit/test_designreviewer_analyzers_cohesion_herencia.py
@@ -10,8 +10,6 @@ Ticket: 3.6
 import textwrap
 from pathlib import Path
 
-import pytest
-
 from quality_agents.designreviewer.analyzers.dit_analyzer import DITAnalyzer
 from quality_agents.designreviewer.analyzers.lcom_analyzer import LCOMAnalyzer
 from quality_agents.designreviewer.analyzers.nop_analyzer import NOPAnalyzer
@@ -20,7 +18,6 @@ from quality_agents.designreviewer.config import DesignReviewerConfig
 from quality_agents.designreviewer.models import ReviewResult, ReviewSeverity
 from quality_agents.designreviewer.orchestrator import AnalyzerOrchestrator
 from quality_agents.shared.verifiable import ExecutionContext
-
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Helpers

--- a/tests/unit/test_designreviewer_analyzers_smells.py
+++ b/tests/unit/test_designreviewer_analyzers_smells.py
@@ -11,8 +11,6 @@ Ticket: 4.6
 import textwrap
 from pathlib import Path
 
-import pytest
-
 from quality_agents.designreviewer.analyzers.data_clumps_analyzer import DataClumpsAnalyzer
 from quality_agents.designreviewer.analyzers.feature_envy_analyzer import FeatureEnvyAnalyzer
 from quality_agents.designreviewer.analyzers.god_object_analyzer import GodObjectAnalyzer
@@ -24,7 +22,6 @@ from quality_agents.designreviewer.config import DesignReviewerConfig
 from quality_agents.designreviewer.models import ReviewResult, ReviewSeverity, SolidPrinciple
 from quality_agents.designreviewer.orchestrator import AnalyzerOrchestrator
 from quality_agents.shared.verifiable import ExecutionContext
-
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Helpers

--- a/tests/unit/test_designreviewer_config.py
+++ b/tests/unit/test_designreviewer_config.py
@@ -4,7 +4,6 @@ Tests unitarios para DesignReviewerConfig y load_config().
 Ticket: 1.7
 """
 
-from pathlib import Path
 
 import pytest
 

--- a/tests/unit/test_designreviewer_formatter.py
+++ b/tests/unit/test_designreviewer_formatter.py
@@ -11,17 +11,10 @@ from pathlib import Path
 import pytest
 
 from quality_agents.designreviewer.formatter import (
-    _print_blocking_issues,
-    _print_effort_summary,
-    _print_header,
-    _print_stats,
-    _print_success,
-    _print_summary,
     format_json,
     format_results,
 )
 from quality_agents.designreviewer.models import ReviewResult, ReviewSeverity, SolidPrinciple
-
 
 # --- Fixtures ---
 

--- a/tests/unit/test_designreviewer_models.py
+++ b/tests/unit/test_designreviewer_models.py
@@ -6,8 +6,6 @@ Ticket: 1.7
 
 from pathlib import Path
 
-import pytest
-
 from quality_agents.designreviewer.models import ReviewResult, ReviewSeverity
 
 

--- a/tests/unit/test_designreviewer_orchestrator.py
+++ b/tests/unit/test_designreviewer_orchestrator.py
@@ -8,13 +8,10 @@ from pathlib import Path
 from typing import Any, List
 from unittest.mock import patch
 
-import pytest
-
 from quality_agents.designreviewer.config import DesignReviewerConfig
 from quality_agents.designreviewer.models import ReviewResult, ReviewSeverity
 from quality_agents.designreviewer.orchestrator import AnalyzerOrchestrator
 from quality_agents.shared.verifiable import ExecutionContext, Verifiable
-
 
 # ========== Analyzers mock para tests ==========
 


### PR DESCRIPTION
Fase 8: Correcciones de calidad pre-release (ruff + mypy)                                                                   
                                                                                                                              
  Resumen                                                                                                                     
                                                                                                                              
  Resuelve todos los errores de linting y tipos detectados durante el checklist de release de v0.2.0. Con esto el código queda
   listo para taggear y publicar.                                                                                             
                                                                                                                              
  Cambios Principales                                                                                                         

  - mypy: 14 errores corregidos en 7 analyzers — tipos Union[FunctionDef, AsyncFunctionDef], manejo de end_lineno nullable, y
  type: ignore[import-untyped] para radon
  - ruff: 29 errores corregidos — imports desordenados, f-strings sin placeholders, imports no usados, # noqa: E402 en imports
   mid-file de agent.py
  - Tests: limpieza de imports superfluos detectados por ruff en 8 archivos de tests

  Impacto

  - Tests: 517 pasando (sin cambios en cantidad)
  - Archivos: 20 modificados
  - mypy: 0 errores en 43 archivos fuente ✅

  Checklist

  - Tests pasando (517)
  - mypy limpio
  - ruff limpio
  - Documentación actualizada (no aplica — solo correcciones de tipos)
