### PR TITLE
Fase 8: Correcciones de calidad pre-release (ruff + mypy)

### DIFF
--- a/src/quality_agents/architectanalyst/metrics/dependency_cycles_analyzer.py
+++ b/src/quality_agents/architectanalyst/metrics/dependency_cycles_analyzer.py
@@ -14,9 +14,12 @@ Fecha: 2026-03-01
 
 import logging
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, List, Set
 
-from quality_agents.architectanalyst.metrics.dependency_graph import DependencyGraphBuilder
+from quality_agents.architectanalyst.metrics.dependency_graph import (
+    DependencyGraph,
+    DependencyGraphBuilder,
+)
 from quality_agents.architectanalyst.models import ArchitectureResult, ArchitectureSeverity
 from quality_agents.architectanalyst.orchestrator import ProjectMetric
 
@@ -102,7 +105,7 @@ class DependencyCyclesAnalyzer(ProjectMetric):
     # Algoritmo de Tarjan para SCCs
     # -------------------------------------------------------------------------
 
-    def _find_cycles_tarjan(self, graph: "DependencyGraphBuilder") -> List[List[str]]:  # type: ignore[name-defined]
+    def _find_cycles_tarjan(self, graph: DependencyGraph) -> List[List[str]]:
         """
         Encuentra SCCs con ≥ 2 nodos usando el algoritmo de Tarjan.
 

--- a/src/quality_agents/architectanalyst/metrics/instability_analyzer.py
+++ b/src/quality_agents/architectanalyst/metrics/instability_analyzer.py
@@ -102,9 +102,9 @@ class InstabilityAnalyzer(ProjectMetric):
 
         return results
 
+    def __init__(self) -> None:
+        self._config: Any = None
+
     def should_run(self, config: Any) -> bool:
         self._config = config
         return True
-
-    def __init__(self) -> None:
-        self._config: Any = None

--- a/src/quality_agents/architectanalyst/metrics/layer_violations_analyzer.py
+++ b/src/quality_agents/architectanalyst/metrics/layer_violations_analyzer.py
@@ -79,7 +79,7 @@ class LayerViolationsAnalyzer(ProjectMetric):
         self._config = config
         if config is None:
             return False
-        return config.layers.is_configured()
+        return bool(config.layers.is_configured())
 
     def analyze(self, project_path: Path, files: List[Path]) -> List[ArchitectureResult]:
         """

--- a/src/quality_agents/architectanalyst/snapshots.py
+++ b/src/quality_agents/architectanalyst/snapshots.py
@@ -166,7 +166,8 @@ class SnapshotStore:
     def get_snapshot_count(self) -> int:
         """Retorna el número total de snapshots almacenados."""
         with sqlite3.connect(self.db_path) as conn:
-            return conn.execute("SELECT COUNT(*) FROM snapshots").fetchone()[0]
+            row = conn.execute("SELECT COUNT(*) FROM snapshots").fetchone()
+            return int(row[0])
 
     # -------------------------------------------------------------------------
     # Helpers privados

--- a/tests/unit/test_architectanalyst_metrics_fase2.py
+++ b/tests/unit/test_architectanalyst_metrics_fase2.py
@@ -13,7 +13,6 @@ Fecha: 2026-03-01
 """
 
 from pathlib import Path
-from unittest.mock import MagicMock
 
 import pytest
 
@@ -27,7 +26,6 @@ from quality_agents.architectanalyst.metrics.dependency_graph import (
 from quality_agents.architectanalyst.metrics.distance_analyzer import DistanceAnalyzer
 from quality_agents.architectanalyst.metrics.instability_analyzer import InstabilityAnalyzer
 from quality_agents.architectanalyst.models import ArchitectureSeverity
-
 
 # =============================================================================
 # Fixtures: proyecto sintético en tmp_path
@@ -289,7 +287,7 @@ class TestInstabilityAnalyzer:
         # Con umbral 0.0, todos los módulos con I > 0 deberían ser WARNING
         assert all(r.severity == ArchitectureSeverity.WARNING for r in results)
 
-    def test_metric_name_es_I(
+    def test_metric_name_es_I(  # noqa: N802
         self, proyecto_simple: Path, files_simple: list
     ) -> None:
         analyzer = InstabilityAnalyzer()
@@ -407,7 +405,7 @@ class TestAbstractnessAnalyzer:
         assert result is not None
         assert result.value == pytest.approx(0.0)
 
-    def test_metric_name_es_A(
+    def test_metric_name_es_A(  # noqa: N802
         self, proyecto_simple: Path, files_simple: list
     ) -> None:
         analyzer = AbstractnessAnalyzer()
@@ -471,7 +469,7 @@ class TestDistanceAnalyzer:
         )
         assert abstracto_result is None
 
-    def test_metric_name_es_D(self, proyecto_simple: Path, files_simple: list) -> None:
+    def test_metric_name_es_D(self, proyecto_simple: Path, files_simple: list) -> None:  # noqa: N802
         analyzer = DistanceAnalyzer()
         config = ArchitectAnalystConfig(max_distance_warning=0.0, max_distance_critical=0.0)
         analyzer.should_run(config)

--- a/tests/unit/test_architectanalyst_metrics_fase3.py
+++ b/tests/unit/test_architectanalyst_metrics_fase3.py
@@ -11,8 +11,6 @@ Fecha: 2026-03-01
 
 from pathlib import Path
 
-import pytest
-
 from quality_agents.architectanalyst.config import ArchitectAnalystConfig, LayersConfig
 from quality_agents.architectanalyst.metrics.dependency_cycles_analyzer import (
     DependencyCyclesAnalyzer,
@@ -21,7 +19,6 @@ from quality_agents.architectanalyst.metrics.layer_violations_analyzer import (
     LayerViolationsAnalyzer,
 )
 from quality_agents.architectanalyst.models import ArchitectureSeverity
-
 
 # =============================================================================
 # Helpers para construir proyectos sintéticos

--- a/tests/unit/test_architectanalyst_models.py
+++ b/tests/unit/test_architectanalyst_models.py
@@ -70,15 +70,15 @@ class TestArchitectureResultCampos:
 
     def _resultado_info(self, **kwargs) -> ArchitectureResult:
         """Fixture: resultado informativo sin umbral (Ca)."""
-        defaults = dict(
-            analyzer_name="CouplingAnalyzer",
-            metric_name="Ca",
-            module_path=Path("src/domain/service.py"),
-            value=3.0,
-            threshold=None,
-            severity=ArchitectureSeverity.INFO,
-            message="3 módulos dependen de este",
-        )
+        defaults = {  # noqa: C408
+            "analyzer_name": "CouplingAnalyzer",
+            "metric_name": "Ca",
+            "module_path": Path("src/domain/service.py"),
+            "value": 3.0,
+            "threshold": None,
+            "severity": ArchitectureSeverity.INFO,
+            "message": "3 módulos dependen de este",
+        }
         defaults.update(kwargs)
         return ArchitectureResult(**defaults)
 

--- a/tests/unit/test_architectanalyst_orchestrator.py
+++ b/tests/unit/test_architectanalyst_orchestrator.py
@@ -15,7 +15,6 @@ from quality_agents.architectanalyst.config import ArchitectAnalystConfig
 from quality_agents.architectanalyst.models import ArchitectureResult, ArchitectureSeverity
 from quality_agents.architectanalyst.orchestrator import MetricOrchestrator, ProjectMetric
 
-
 # ========== Métricas mock para tests ==========
 
 

--- a/tests/unit/test_architectanalyst_tendencias.py
+++ b/tests/unit/test_architectanalyst_tendencias.py
@@ -22,7 +22,6 @@ from quality_agents.architectanalyst.models import (
 from quality_agents.architectanalyst.snapshots import SnapshotStore
 from quality_agents.architectanalyst.trends import TrendCalculator
 
-
 # =============================================================================
 # Fixtures
 # =============================================================================


### PR DESCRIPTION
Fase 8: Correcciones de calidad pre-release — ruff + mypy limpios                                                
                                                                                                                   
  Resumen
                                                                                                                   
  Corrige todos los errores de ruff (11) y mypy (7) encontrados al correr la suite completa de calidad pre-release.
   El paquete v0.3.0 construye limpio y pasa twine check. Sin cambios funcionales — solo correcciones de tipos,
  imports y naming.

  Cambios Principales

  - ruff (11 errores → 0): imports unused removidos, imports reordenados, # noqa: N802 en tests con nombres de
  métricas (I/A/D), dict() → literal
  - mypy (7 errores → 0): tipo correcto DependencyGraph en _find_cycles_tarjan, int() explícito en snapshots.py,
  bool() en layer_violations_analyzer, __init__ reubicado en instability_analyzer
  - Build: quality_agents-0.3.0.whl (113K) + .tar.gz (234K) — twine check PASSED

  Impacto

  - Tests: 766/766 pasando (sin cambios)
  - Archivos: 9 modificados (solo correcciones, sin archivos nuevos)
  - Líneas: diff mínimo (~24 ins / ~27 del)

  Checklist

  - 766/766 tests pasando
  - ruff: 0 errores
  - mypy: 0 errores
  - Build limpio + twine check PASSED