### PR TITLE
Fix #44: ignorar claves desconocidas en from_pyproject_toml() con warning visible

### DIFF
--- a/src/quality_agents/architectanalyst/config.py
+++ b/src/quality_agents/architectanalyst/config.py
@@ -5,6 +5,7 @@ Fecha de creación: 2026-02-28
 Ticket: 1.4
 """
 
+import dataclasses
 import logging
 import sys
 from dataclasses import dataclass, field
@@ -12,6 +13,15 @@ from pathlib import Path
 from typing import Dict, List, Optional
 
 logger = logging.getLogger(__name__)
+
+
+def _filter_fields(cls: type, data: dict) -> dict:
+    """Filtra un dict dejando solo las claves que son campos del dataclass."""
+    known = {f.name for f in dataclasses.fields(cls)}
+    for key in set(data) - known:
+        logger.warning(f"[tool.architectanalyst] clave desconocida ignorada: '{key}'")
+    return {k: v for k, v in data.items() if k in known}
+
 
 # Python 3.11+ tiene tomllib en stdlib, versiones anteriores usan tomli
 if sys.version_info >= (3, 11):
@@ -141,10 +151,10 @@ class ArchitectAnalystConfig:
         ai_data = tool_config.pop("ai", {})
         layers_data = tool_config.pop("layers", {})
 
-        ai_config = AIConfig(**ai_data) if ai_data else AIConfig()
+        ai_config = AIConfig(**_filter_fields(AIConfig, ai_data)) if ai_data else AIConfig()
         layers_config = LayersConfig(rules=layers_data) if layers_data else LayersConfig()
 
-        config = cls(**tool_config)
+        config = cls(**_filter_fields(cls, tool_config))
         config.ai = ai_config
         config.layers = layers_config
         return config

--- a/src/quality_agents/codeguard/config.py
+++ b/src/quality_agents/codeguard/config.py
@@ -2,6 +2,7 @@
 Configuración para CodeGuard.
 """
 
+import dataclasses
 import logging
 import sys
 from dataclasses import dataclass, field
@@ -11,6 +12,15 @@ from typing import List, Optional
 import yaml
 
 logger = logging.getLogger(__name__)
+
+
+def _filter_fields(cls: type, data: dict) -> dict:
+    """Filtra un dict dejando solo las claves que son campos del dataclass."""
+    known = {f.name for f in dataclasses.fields(cls)}
+    for key in set(data) - known:
+        logger.warning(f"[tool.codeguard] clave desconocida ignorada: '{key}'")
+    return {k: v for k, v in data.items() if k in known}
+
 
 # Python 3.11+ tiene tomllib en stdlib, versiones anteriores usan tomli
 if sys.version_info >= (3, 11):
@@ -81,10 +91,10 @@ class CodeGuardConfig:
 
         # Extraer configuración de IA si existe
         ai_data = data.pop("ai", {})
-        ai_config = AIConfig(**ai_data) if ai_data else AIConfig()
+        ai_config = AIConfig(**_filter_fields(AIConfig, ai_data)) if ai_data else AIConfig()
 
         # Crear instancia con el resto de la configuración
-        config = cls(**data)
+        config = cls(**_filter_fields(cls, data))
         config.ai = ai_config
 
         return config
@@ -127,10 +137,10 @@ class CodeGuardConfig:
 
         # Extraer configuración de IA si existe
         ai_config_data = tool_config.pop("ai", {})
-        ai_config = AIConfig(**ai_config_data) if ai_config_data else AIConfig()
+        ai_config = AIConfig(**_filter_fields(AIConfig, ai_config_data)) if ai_config_data else AIConfig()
 
         # Crear instancia con el resto de la configuración
-        config = cls(**tool_config)
+        config = cls(**_filter_fields(cls, tool_config))
         config.ai = ai_config
 
         return config

--- a/src/quality_agents/designreviewer/config.py
+++ b/src/quality_agents/designreviewer/config.py
@@ -5,6 +5,7 @@ Fecha de creación: 2026-02-19
 Ticket: 1.5
 """
 
+import dataclasses
 import logging
 import sys
 from dataclasses import dataclass, field
@@ -12,6 +13,15 @@ from pathlib import Path
 from typing import List, Optional
 
 logger = logging.getLogger(__name__)
+
+
+def _filter_fields(cls: type, data: dict) -> dict:
+    """Filtra un dict dejando solo las claves que son campos del dataclass."""
+    known = {f.name for f in dataclasses.fields(cls)}
+    for key in set(data) - known:
+        logger.warning(f"[tool.designreviewer] clave desconocida ignorada: '{key}'")
+    return {k: v for k, v in data.items() if k in known}
+
 
 # Python 3.11+ tiene tomllib en stdlib, versiones anteriores usan tomli
 if sys.version_info >= (3, 11):
@@ -112,9 +122,9 @@ class DesignReviewerConfig:
 
         # Extraer sub-sección de IA
         ai_data = tool_config.pop("ai", {})
-        ai_config = AIConfig(**ai_data) if ai_data else AIConfig()
+        ai_config = AIConfig(**_filter_fields(AIConfig, ai_data)) if ai_data else AIConfig()
 
-        config = cls(**tool_config)
+        config = cls(**_filter_fields(cls, tool_config))
         config.ai = ai_config
         return config
 

--- a/tests/unit/test_architectanalyst_config.py
+++ b/tests/unit/test_architectanalyst_config.py
@@ -195,6 +195,40 @@ key = "value"
         with pytest.raises(FileNotFoundError):
             ArchitectAnalystConfig.from_pyproject_toml(pyproject)
 
+    def test_from_pyproject_toml_claves_desconocidas_ignoradas(self, tmp_path):
+        """Claves desconocidas en [tool.architectanalyst] deben ignorarse sin lanzar excepción."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text("""
+[tool.architectanalyst]
+max_instability = 0.7
+layer_roles = { "*/application/*" = "leaf" }
+sprint_cadence = "2w"
+""")
+
+        config = ArchitectAnalystConfig.from_pyproject_toml(pyproject)
+
+        assert config.max_instability == 0.7
+        assert config.max_distance_warning == 0.3  # default no pisado
+
+    def test_from_pyproject_toml_claves_desconocidas_loguea_warning(self, tmp_path, caplog):
+        """Claves desconocidas deben generar un WARNING por cada una."""
+        import logging
+
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text("""
+[tool.architectanalyst]
+max_instability = 0.7
+layer_roles = { "*/application/*" = "leaf" }
+sprint_cadence = "2w"
+""")
+
+        with caplog.at_level(logging.WARNING, logger="quality_agents.architectanalyst.config"):
+            ArchitectAnalystConfig.from_pyproject_toml(pyproject)
+
+        warned_keys = [r.message for r in caplog.records if "desconocida" in r.message]
+        assert any("layer_roles" in msg for msg in warned_keys)
+        assert any("sprint_cadence" in msg for msg in warned_keys)
+
 
 class TestLoadConfig:
     """Tests para la función load_config()."""

--- a/tests/unit/test_codeguard_config.py
+++ b/tests/unit/test_codeguard_config.py
@@ -178,6 +178,40 @@ ai:
         assert config.min_pylint_score == 8.0
         assert config.ai.enabled is False
 
+    def test_from_pyproject_toml_claves_desconocidas_ignoradas(self, tmp_path):
+        """Claves desconocidas en [tool.codeguard] deben ignorarse sin lanzar excepción."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text("""
+[tool.codeguard]
+min_pylint_score = 7.0
+paths = ["src"]
+check_hexagonal = true
+""")
+
+        config = CodeGuardConfig.from_pyproject_toml(pyproject)
+
+        assert config.min_pylint_score == 7.0
+        assert config.max_cyclomatic_complexity == 10  # default no pisado
+
+    def test_from_pyproject_toml_claves_desconocidas_loguea_warning(self, tmp_path, caplog):
+        """Claves desconocidas deben generar un WARNING por cada una."""
+        import logging
+
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text("""
+[tool.codeguard]
+min_pylint_score = 7.0
+paths = ["src"]
+check_hexagonal = true
+""")
+
+        with caplog.at_level(logging.WARNING, logger="quality_agents.codeguard.config"):
+            CodeGuardConfig.from_pyproject_toml(pyproject)
+
+        warned_keys = [r.message for r in caplog.records if "desconocida" in r.message]
+        assert any("paths" in msg for msg in warned_keys)
+        assert any("check_hexagonal" in msg for msg in warned_keys)
+
     def test_to_yaml(self, tmp_path):
         """Debe guardar configuración a YAML correctamente."""
         config = CodeGuardConfig(

--- a/tests/unit/test_designreviewer_config.py
+++ b/tests/unit/test_designreviewer_config.py
@@ -121,6 +121,41 @@ key = "value"
         with pytest.raises(FileNotFoundError):
             DesignReviewerConfig.from_pyproject_toml(pyproject)
 
+    def test_from_pyproject_toml_claves_desconocidas_ignoradas(self, tmp_path):
+        """Claves desconocidas en [tool.designreviewer] deben ignorarse sin lanzar excepción."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text("""
+[tool.designreviewer]
+max_cbo = 10
+paths = ["src"]
+check_hexagonal = true
+forbidden_imports_in_domain = ["infrastructure"]
+""")
+
+        config = DesignReviewerConfig.from_pyproject_toml(pyproject)
+
+        assert config.max_cbo == 10
+        assert config.max_fan_out == 7  # default no pisado
+
+    def test_from_pyproject_toml_claves_desconocidas_loguea_warning(self, tmp_path, caplog):
+        """Claves desconocidas deben generar un WARNING por cada una."""
+        import logging
+
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text("""
+[tool.designreviewer]
+max_cbo = 10
+paths = ["src"]
+check_hexagonal = true
+""")
+
+        with caplog.at_level(logging.WARNING, logger="quality_agents.designreviewer.config"):
+            DesignReviewerConfig.from_pyproject_toml(pyproject)
+
+        warned_keys = [r.message for r in caplog.records if "desconocida" in r.message]
+        assert any("paths" in msg for msg in warned_keys)
+        assert any("check_hexagonal" in msg for msg in warned_keys)
+
 
 class TestLoadConfig:
     """Tests para la función load_config()."""


### PR DESCRIPTION
## Problema

`from_pyproject_toml()` usaba `cls(**tool_config)` directamente. Si `[tool.designreviewer]` (o codeguard / architectanalyst) contenía claves que no son campos del dataclass, Python lanzaba `TypeError` silenciado por `load_config()`, haciendo que la herramienta corriera con defaults **sin avisar al usuario**.

Detectado en el proyecto AtaraxiaDive: `max_cbo = 10` configurado para DDD nunca se aplicó, y la herramienta bloqueó PRs que no deberían haberse bloqueado.

## Solución

Agregado `_filter_fields(cls, data)` en los tres `config.py`:
- Filtra el dict contra `dataclasses.fields(cls)`
- Emite un `WARNING` visible por **cada clave ignorada**
- Aplica tanto al dataclass principal como a `AIConfig`

```
WARNING: [tool.designreviewer] clave desconocida ignorada: 'paths'
WARNING: [tool.designreviewer] clave desconocida ignorada: 'check_hexagonal'
```

## Archivos modificados

- `src/quality_agents/designreviewer/config.py`
- `src/quality_agents/codeguard/config.py`
- `src/quality_agents/architectanalyst/config.py`
- `tests/unit/test_designreviewer_config.py` (+2 tests)
- `tests/unit/test_codeguard_config.py` (+2 tests)
- `tests/unit/test_architectanalyst_config.py` (+2 tests)

## Test plan

- [x] 6 tests nuevos (2 por agente): uno verifica que la config carga correctamente con claves desconocidas presentes, otro verifica que se emiten los WARNINGs
- [x] 65 tests de config pasando
- [x] `ruff check` limpio
- [x] `mypy` limpio

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)