### PR TITLE
Incremento 1: Fundamentos de UX y Configuración (#53 #56 #60 #61 #62)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,82 @@ y este proyecto adhiere a [Semantic Versioning](https://semver.org/lang/es/).
 
 ## [Unreleased]
 
+### ✨ Improvements — Incremento 1: Fundamentos de UX y Configuración
+
+#### Fix #53 / #56: Output agrupado por módulo (`directorio/archivo.py`)
+
+Los formatters de CodeGuard y DesignReviewer agrupaban por paquete (directorio padre), lo que causaba colisiones cuando archivos `__init__.py` de distintos directorios se fusionaban bajo la misma clave.
+
+**Fix:** la clave de agrupación ahora es `directorio/archivo.py` — combinación del directorio padre con el nombre del archivo. Esto garantiza unicidad y mejora la navegabilidad del output.
+
+```
+# Antes
+📦  codeguard  (24 issues)   ← mezclaba archivos de tres directorios
+
+# Ahora
+📄  codeguard/formatter.py  (3 issues)
+📄  codeguard/config.py     (1 issue)
+📄  shared/__init__.py      (2 issues)
+```
+
+En JSON: la sección `by_package` pasó a llamarse `by_module`, con claves `"directorio/archivo.py"`.
+
+#### Fix #60: CodeGuard — toggles por verificación en `[tool.codeguard.checks]`
+
+Las verificaciones individuales (pep8, pylint, security, complexity, types, imports) solo podían habilitarse o deshabilitarse con campos de primer nivel en `[tool.codeguard]`. Esto mezclaba configuración de umbrales con toggles booleanos y no seguía el patrón estándar de subsecciones TOML.
+
+**Fix:** los toggles se movieron a la subsección `[tool.codeguard.checks]`:
+
+```toml
+[tool.codeguard.checks]
+pep8 = true
+pylint = true
+security = false   # deshabilitar bandit
+complexity = true
+types = true
+imports = true
+```
+
+En YAML:
+```yaml
+checks:
+  security: false
+```
+
+> **Nota de migración:** los campos `check_pep8`, `check_pylint`, etc. en `[tool.codeguard]` ya no son válidos. Moverlos a `[tool.codeguard.checks]` sin el prefijo `check_`.
+
+#### Fix #61: DesignReviewer — toggles por analyzer en `[tool.designreviewer.checks]`
+
+```toml
+[tool.designreviewer.checks]
+cbo = true
+fan_out = true
+circular_imports = true
+lcom = true
+wmc = true
+dit = true
+nop = true
+god_object = true
+long_method = true
+long_parameter_list = true
+feature_envy = false   # deshabilitar para este proyecto
+data_clumps = false
+```
+
+#### Fix #62: ArchitectAnalyst — toggles por métrica en `[tool.architectanalyst.checks]`
+
+```toml
+[tool.architectanalyst.checks]
+coupling = true
+abstractness = true
+instability = true
+distance = true
+dependency_cycles = true
+layer_violations = false   # solo si no se declaran capas
+```
+
+---
+
 ### 🐛 Bug Fixes — CodeGuard y DesignReviewer
 
 #### Fix #36 / #39: `exclude_patterns` no se aplicaba en `collect_files`

--- a/docs/guias/adopcion-codeguard.md
+++ b/docs/guias/adopcion-codeguard.md
@@ -75,12 +75,6 @@ max_cyclomatic_complexity = 15   # default: 10 — empezar más permisivo
 max_line_length = 120            # default: 100 — ajustar al estilo existente
 min_pylint_score = 6.0           # default: 8.0 — bajar si el score actual es bajo
 
-# Activar solo los checks que agreguen valor ahora
-check_pep8 = true
-check_security = true            # seguridad siempre activa
-check_complexity = true
-check_types = false              # desactivar si no hay type hints en el proyecto
-
 # Excluir lo que no controlás
 exclude_patterns = [
     "tests/*",
@@ -89,6 +83,13 @@ exclude_patterns = [
     ".venv/*",
     "setup.py",
 ]
+
+# Activar solo los checks que agreguen valor ahora
+[tool.codeguard.checks]
+pep8 = true
+security = true            # seguridad siempre activa
+complexity = true
+types = false              # desactivar si no hay type hints en el proyecto
 ```
 
 **Estrategia de mejora gradual:**
@@ -96,9 +97,9 @@ exclude_patterns = [
 | Semana | Acción |
 |--------|--------|
 | 1-2 | Corrida exploratoria, configurar umbrales actuales |
-| 3-4 | Activar `check_security`, resolver errores críticos |
+| 3-4 | Activar `security = true`, resolver errores críticos |
 | 5-8 | Bajar `max_cyclomatic_complexity` de a 1 por semana |
-| 9+  | Activar `check_types`, agregar type hints progresivamente |
+| 9+  | Activar `types = true`, agregar type hints progresivamente |
 
 ### Paso 3: Integrar con pre-commit (cuando el equipo esté listo)
 
@@ -162,16 +163,17 @@ max_cyclomatic_complexity = 10
 max_line_length = 100
 min_pylint_score = 8.0
 
-# Todos los checks activos
-check_pep8 = true
-check_security = true
-check_complexity = true
-check_types = true        # type hints desde el primer módulo
-
 exclude_patterns = [
     "tests/*",
     ".venv/*",
 ]
+
+# Todos los checks activos
+[tool.codeguard.checks]
+pep8 = true
+security = true
+complexity = true
+types = true        # type hints desde el primer módulo
 ```
 
 ### Paso 3: Pre-commit desde el primer commit
@@ -230,14 +232,6 @@ Todas las opciones disponibles en `[tool.codeguard]`:
 
 ```toml
 [tool.codeguard]
-# --- Checks activos ---
-check_pep8 = true                # Estilo PEP8 (flake8)
-check_security = true            # Vulnerabilidades (bandit)
-check_complexity = true          # Complejidad ciclomática (radon)
-check_types = true               # Tipos (mypy)
-check_pylint = true              # Score general (pylint)
-check_imports = true             # Imports sin usar (pylint)
-
 # --- Umbrales ---
 max_cyclomatic_complexity = 10   # Complejidad máxima por función
 max_line_length = 100            # Longitud máxima de línea
@@ -249,6 +243,15 @@ exclude_patterns = [
     "migrations/*",
     ".venv/*",
 ]
+
+# --- Checks activos (todos habilitados por defecto) ---
+[tool.codeguard.checks]
+pep8 = true                # Estilo PEP8 (flake8)
+security = true            # Vulnerabilidades (bandit)
+complexity = true          # Complejidad ciclomática (radon)
+types = true               # Tipos (mypy)
+pylint = true              # Score general (pylint)
+imports = true             # Imports sin usar (pylint)
 
 # --- IA opcional (requiere API key de Anthropic) ---
 [tool.codeguard.ai]
@@ -285,7 +288,7 @@ codeguard src/ --format json > out.json
 | | Proyecto existente | Proyecto nuevo |
 |---|---|---|
 | **Umbrales iniciales** | Laxos, ajustar gradualmente | Estrictos desde el inicio |
-| **`check_types`** | Desactivar si no hay type hints | Activar desde el primer módulo |
+| **`checks.types`** | Desactivar si no hay type hints | Activar desde el primer módulo |
 | **Pre-commit** | Agregar cuando el equipo esté listo | Antes del primer commit |
 | **Primera corrida** | Exploratoria, generar baseline | Debe dar 0 errores |
 | **Estrategia** | Mejora gradual semana a semana | Mantener verde desde el día uno |

--- a/docs/guias/architectanalyst.md
+++ b/docs/guias/architectanalyst.md
@@ -283,6 +283,15 @@ exclude_patterns = [
     "build",
 ]
 
+# Métricas habilitadas (todas activas por defecto)
+[tool.architectanalyst.checks]
+coupling = true
+abstractness = true
+instability = true
+distance = true
+dependency_cycles = true
+layer_violations = true
+
 # IA (opt-in — desactivada por defecto)
 [tool.architectanalyst.ai]
 enabled = false
@@ -293,6 +302,14 @@ max_tokens = 1500
 domain = []
 application = ["domain"]
 infrastructure = ["application", "domain"]
+```
+
+### Deshabilitar métricas específicas
+
+```toml
+[tool.architectanalyst.checks]
+layer_violations = false    # Solo si no se usan reglas de capas
+instability = false         # Deshabilitar análisis de inestabilidad
 ```
 
 ### Umbrales por defecto

--- a/docs/guias/codeguard.md
+++ b/docs/guias/codeguard.md
@@ -111,14 +111,6 @@ max_cyclomatic_complexity = 10
 max_line_length = 100
 max_function_lines = 20
 
-# Verificaciones habilitadas
-check_pep8 = true
-check_pylint = true
-check_security = true
-check_complexity = true
-check_types = true
-check_imports = true
-
 # Exclusiones
 exclude_patterns = [
     "*.pyc",
@@ -128,6 +120,15 @@ exclude_patterns = [
     "migrations",
     "tests/*"
 ]
+
+# Verificaciones habilitadas (todas activas por defecto)
+[tool.codeguard.checks]
+pep8 = true
+pylint = true
+security = true
+complexity = true
+types = true
+imports = true
 
 # Configuración de IA (opcional)
 [tool.codeguard.ai]
@@ -153,14 +154,6 @@ max_cyclomatic_complexity: 10
 max_line_length: 100
 max_function_lines: 20
 
-# Verificaciones habilitadas
-check_pep8: true
-check_pylint: true
-check_security: true
-check_complexity: true
-check_types: true
-check_imports: true
-
 # Exclusiones
 exclude_patterns:
   - "*.pyc"
@@ -169,6 +162,15 @@ exclude_patterns:
   - "venv"
   - "migrations"
   - "tests/*"
+
+# Verificaciones habilitadas (todas activas por defecto)
+checks:
+  pep8: true
+  pylint: true
+  security: true
+  complexity: true
+  types: true
+  imports: true
 ```
 
 ### Búsqueda Automática de Configuración
@@ -799,10 +801,18 @@ codeguard /path/to/proyecto
 
 ### ¿Cómo deshabilito una verificación específica?
 
-En tu `.codeguard.yml`:
+En `pyproject.toml`:
+```toml
+[tool.codeguard.checks]
+pep8 = false        # Deshabilitar PEP8
+complexity = false  # Deshabilitar complejidad
+```
+
+O en `.codeguard.yml`:
 ```yaml
-check_pep8: false        # Deshabilitar PEP8
-check_complexity: false  # Deshabilitar complejidad
+checks:
+  pep8: false
+  complexity: false
 ```
 
 ### ¿Cómo excluir archivos o directorios?
@@ -823,24 +833,24 @@ exclude_patterns:
 
 Los patrones se aplican sobre la **ruta relativa** al directorio analizado, no sobre el path absoluto. Un patrón como `"migrations"` excluye cualquier archivo cuyo path relativo contenga esa cadena (p. ej. `app/migrations/0001_initial.py`).
 
-### ¿El output muestra resultados agrupados por paquete?
+### ¿El output muestra resultados agrupados?
 
-Sí. Desde la versión que incluye el fix #37, los resultados se muestran agrupados por directorio padre del archivo:
+Sí. Los resultados se agrupan por **módulo** (`directorio/archivo.py`), lo que permite identificar exactamente qué archivo del proyecto tiene problemas:
 
 ```
-📦  servicios  (3 issues)
+📄  servicios/user_service.py  (3 issues)
   Errores (1) ...
   Advertencias (2) ...
 
-📦  entidades  (1 issue)
+📄  entidades/pedido.py  (1 issue)
   Advertencias (1) ...
 ```
 
-En el output JSON también se incluye la sección `by_package`:
+En el output JSON se incluye la sección `by_module`:
 ```json
-"by_package": {
-  "entidades": [...],
-  "servicios": [...]
+"by_module": {
+  "servicios/user_service.py": [...],
+  "entidades/pedido.py": [...]
 }
 ```
 

--- a/docs/guias/designreviewer.md
+++ b/docs/guias/designreviewer.md
@@ -303,11 +303,36 @@ max_method_lines = 20          # Long Method (warning)
 max_method_lines_critical = 40 # Long Method (critical)
 max_parameters = 4             # Long Parameter List (warning)
 max_parameters_critical = 7    # Long Parameter List (critical)
+
+# Analyzers habilitados (todos activos por defecto)
+[tool.designreviewer.checks]
+cbo = true
+fan_out = true
+circular_imports = true
+lcom = true
+wmc = true
+dit = true
+nop = true
+god_object = true
+long_method = true
+long_parameter_list = true
+feature_envy = true
+data_clumps = true
 ```
 
 ### Valores por defecto
 
 Si no configurás `[tool.designreviewer]`, se usan los umbrales mostrados en la tabla de métricas. Son los valores de la literatura de ingeniería de software.
+
+### Deshabilitar analyzers específicos
+
+Útil para proyectos con restricciones particulares de diseño:
+
+```toml
+[tool.designreviewer.checks]
+feature_envy = false    # Deshabilitar Feature Envy
+data_clumps = false     # Deshabilitar Data Clumps
+```
 
 ---
 
@@ -460,24 +485,24 @@ exclude_patterns = [".venv", "__pycache__", "test_"]
 
 Los patrones se aplican sobre la **ruta relativa** al directorio analizado. Un patrón `"test_"` excluirá cualquier archivo cuyo path relativo contenga esa cadena.
 
-### ¿El output muestra resultados agrupados por paquete?
+### ¿El output muestra resultados agrupados?
 
-Sí. Los resultados se agrupan por directorio padre del archivo, con un encabezado por paquete:
+Sí. Los resultados se agrupan por **módulo** (`directorio/archivo.py`):
 
 ```
-📦  servicios  (2 issues)
+📄  servicios/user_service.py  (2 issues)
   🚫 BLOCKING ISSUES (1)  ...
   Advertencias de Diseño (1)  ...
 
-📦  entidades  (1 issue)
+📄  entidades/pedido.py  (1 issue)
   Advertencias de Diseño (1)  ...
 ```
 
-En el output JSON también se incluye la sección `by_package`:
+En el output JSON se incluye la sección `by_module`:
 ```json
-"by_package": {
-  "entidades": [...],
-  "servicios": [...]
+"by_module": {
+  "entidades/pedido.py": [...],
+  "servicios/user_service.py": [...]
 }
 ```
 

--- a/src/quality_agents/architectanalyst/config.py
+++ b/src/quality_agents/architectanalyst/config.py
@@ -42,6 +42,28 @@ class AIConfig:
 
 
 @dataclass
+class ArchitectAnalystChecksConfig:
+    """
+    Toggles para habilitar/deshabilitar métricas individuales de ArchitectAnalyst.
+
+    Configurable desde pyproject.toml con la sección [tool.architectanalyst.checks].
+
+    Example::
+
+        [tool.architectanalyst.checks]
+        coupling = true
+        distance = false
+    """
+
+    coupling: bool = True
+    abstractness: bool = True
+    instability: bool = True
+    distance: bool = True
+    dependency_cycles: bool = True
+    layer_violations: bool = True
+
+
+@dataclass
 class LayersConfig:
     """
     Configuración de arquitectura en capas.
@@ -109,6 +131,7 @@ class ArchitectAnalystConfig:
     ])
 
     # --- Subsecciones ---
+    checks: ArchitectAnalystChecksConfig = field(default_factory=ArchitectAnalystChecksConfig)
     ai: AIConfig = field(default_factory=AIConfig)
     layers: LayersConfig = field(default_factory=LayersConfig)
 
@@ -150,13 +173,19 @@ class ArchitectAnalystConfig:
         # Extraer sub-secciones antes de pasar el resto al dataclass
         ai_data = tool_config.pop("ai", {})
         layers_data = tool_config.pop("layers", {})
+        checks_data = tool_config.pop("checks", {})
 
         ai_config = AIConfig(**_filter_fields(AIConfig, ai_data)) if ai_data else AIConfig()
         layers_config = LayersConfig(rules=layers_data) if layers_data else LayersConfig()
+        checks_config = (
+            ArchitectAnalystChecksConfig(**_filter_fields(ArchitectAnalystChecksConfig, checks_data))
+            if checks_data else ArchitectAnalystChecksConfig()
+        )
 
         config = cls(**_filter_fields(cls, tool_config))
         config.ai = ai_config
         config.layers = layers_config
+        config.checks = checks_config
         return config
 
 

--- a/src/quality_agents/architectanalyst/metrics/abstractness_analyzer.py
+++ b/src/quality_agents/architectanalyst/metrics/abstractness_analyzer.py
@@ -109,6 +109,8 @@ class AbstractnessAnalyzer(ProjectMetric):
         return results
 
     def should_run(self, config: Any) -> bool:
+        if config and hasattr(config, "checks") and not config.checks.abstractness:
+            return False
         return True
 
     # -------------------------------------------------------------------------

--- a/src/quality_agents/architectanalyst/metrics/coupling_analyzer.py
+++ b/src/quality_agents/architectanalyst/metrics/coupling_analyzer.py
@@ -88,4 +88,6 @@ class CouplingAnalyzer(ProjectMetric):
         return results
 
     def should_run(self, config: Any) -> bool:
+        if config and hasattr(config, "checks") and not config.checks.coupling:
+            return False
         return True

--- a/src/quality_agents/architectanalyst/metrics/dependency_cycles_analyzer.py
+++ b/src/quality_agents/architectanalyst/metrics/dependency_cycles_analyzer.py
@@ -58,6 +58,8 @@ class DependencyCyclesAnalyzer(ProjectMetric):
         return 1
 
     def should_run(self, config: Any) -> bool:
+        if config and hasattr(config, "checks") and not config.checks.dependency_cycles:
+            return False
         return True
 
     def analyze(self, project_path: Path, files: List[Path]) -> List[ArchitectureResult]:

--- a/src/quality_agents/architectanalyst/metrics/distance_analyzer.py
+++ b/src/quality_agents/architectanalyst/metrics/distance_analyzer.py
@@ -81,6 +81,8 @@ class DistanceAnalyzer(ProjectMetric):
 
     def should_run(self, config: Any) -> bool:
         self._config = config
+        if config and hasattr(config, "checks") and not config.checks.distance:
+            return False
         return True
 
     def analyze(self, project_path: Path, files: List[Path]) -> List[ArchitectureResult]:

--- a/src/quality_agents/architectanalyst/metrics/instability_analyzer.py
+++ b/src/quality_agents/architectanalyst/metrics/instability_analyzer.py
@@ -107,4 +107,6 @@ class InstabilityAnalyzer(ProjectMetric):
 
     def should_run(self, config: Any) -> bool:
         self._config = config
+        if config and hasattr(config, "checks") and not config.checks.instability:
+            return False
         return True

--- a/src/quality_agents/architectanalyst/metrics/layer_violations_analyzer.py
+++ b/src/quality_agents/architectanalyst/metrics/layer_violations_analyzer.py
@@ -79,6 +79,8 @@ class LayerViolationsAnalyzer(ProjectMetric):
         self._config = config
         if config is None:
             return False
+        if hasattr(config, "checks") and not config.checks.layer_violations:
+            return False
         return bool(config.layers.is_configured())
 
     def analyze(self, project_path: Path, files: List[Path]) -> List[ArchitectureResult]:

--- a/src/quality_agents/codeguard/checks/complexity_check.py
+++ b/src/quality_agents/codeguard/checks/complexity_check.py
@@ -83,7 +83,7 @@ class ComplexityCheck(Verifiable):
             return False
 
         # Verificar si está habilitado en config
-        if context.config and not context.config.check_complexity:
+        if context.config and not context.config.checks.complexity:
             return False
 
         return True

--- a/src/quality_agents/codeguard/checks/import_check.py
+++ b/src/quality_agents/codeguard/checks/import_check.py
@@ -82,7 +82,7 @@ class ImportCheck(Verifiable):
             return False
 
         # Verificar si está habilitado en config
-        if context.config and not context.config.check_imports:
+        if context.config and not context.config.checks.imports:
             return False
 
         return True

--- a/src/quality_agents/codeguard/checks/pep8_check.py
+++ b/src/quality_agents/codeguard/checks/pep8_check.py
@@ -74,7 +74,7 @@ class PEP8Check(Verifiable):
             return False
 
         # Verificar si está habilitado en config
-        if context.config and not context.config.check_pep8:
+        if context.config and not context.config.checks.pep8:
             return False
 
         return True

--- a/src/quality_agents/codeguard/checks/pylint_check.py
+++ b/src/quality_agents/codeguard/checks/pylint_check.py
@@ -78,7 +78,7 @@ class PylintCheck(Verifiable):
             return False
 
         # Verificar si está habilitado en config
-        if context.config and not context.config.check_pylint:
+        if context.config and not context.config.checks.pylint:
             return False
 
         return True

--- a/src/quality_agents/codeguard/checks/security_check.py
+++ b/src/quality_agents/codeguard/checks/security_check.py
@@ -81,7 +81,7 @@ class SecurityCheck(Verifiable):
             return False
 
         # Verificar si está habilitado en config
-        if context.config and not context.config.check_security:
+        if context.config and not context.config.checks.security:
             return False
 
         return True

--- a/src/quality_agents/codeguard/checks/type_check.py
+++ b/src/quality_agents/codeguard/checks/type_check.py
@@ -83,7 +83,7 @@ class TypeCheck(Verifiable):
             return False
 
         # Verificar si está habilitado en config
-        if context.config and not context.config.check_types:
+        if context.config and not context.config.checks.types:
             return False
 
         # Verificar si el archivo tiene type hints

--- a/src/quality_agents/codeguard/config.py
+++ b/src/quality_agents/codeguard/config.py
@@ -43,6 +43,29 @@ class AIConfig:
 
 
 @dataclass
+class ChecksConfig:
+    """
+    Toggles para habilitar/deshabilitar checks individuales de CodeGuard.
+
+    Configurable desde pyproject.toml con la sección [tool.codeguard.checks]
+    o desde YAML con la clave ``checks``.
+
+    Example::
+
+        [tool.codeguard.checks]
+        pep8 = false
+        security = true
+    """
+
+    pep8: bool = True
+    pylint: bool = True
+    security: bool = True
+    complexity: bool = True
+    types: bool = True
+    imports: bool = True
+
+
+@dataclass
 class CodeGuardConfig:
     """Configuración de CodeGuard."""
 
@@ -52,14 +75,6 @@ class CodeGuardConfig:
     max_line_length: int = 100
     max_function_lines: int = 20
 
-    # Verificaciones habilitadas
-    check_pep8: bool = True
-    check_pylint: bool = True
-    check_security: bool = True
-    check_complexity: bool = True
-    check_types: bool = True
-    check_imports: bool = True
-
     # Exclusiones
     exclude_patterns: List[str] = field(default_factory=lambda: [
         "*.pyc",
@@ -68,6 +83,9 @@ class CodeGuardConfig:
         "venv",
         "migrations",
     ])
+
+    # Toggles de checks
+    checks: ChecksConfig = field(default_factory=ChecksConfig)
 
     # Configuración de IA
     ai: AIConfig = field(default_factory=AIConfig)
@@ -89,13 +107,15 @@ class CodeGuardConfig:
         if not data:
             return cls()
 
-        # Extraer configuración de IA si existe
+        # Extraer sub-secciones antes de pasar el resto al dataclass
         ai_data = data.pop("ai", {})
+        checks_data = data.pop("checks", {})
         ai_config = AIConfig(**_filter_fields(AIConfig, ai_data)) if ai_data else AIConfig()
+        checks_config = ChecksConfig(**_filter_fields(ChecksConfig, checks_data)) if checks_data else ChecksConfig()
 
-        # Crear instancia con el resto de la configuración
         config = cls(**_filter_fields(cls, data))
         config.ai = ai_config
+        config.checks = checks_config
 
         return config
 
@@ -135,13 +155,15 @@ class CodeGuardConfig:
             # No hay configuración de codeguard, retornar defaults
             return cls()
 
-        # Extraer configuración de IA si existe
+        # Extraer sub-secciones antes de pasar el resto al dataclass
         ai_config_data = tool_config.pop("ai", {})
+        checks_data = tool_config.pop("checks", {})
         ai_config = AIConfig(**_filter_fields(AIConfig, ai_config_data)) if ai_config_data else AIConfig()
+        checks_config = ChecksConfig(**_filter_fields(ChecksConfig, checks_data)) if checks_data else ChecksConfig()
 
-        # Crear instancia con el resto de la configuración
         config = cls(**_filter_fields(cls, tool_config))
         config.ai = ai_config
+        config.checks = checks_config
 
         return config
 
@@ -157,13 +179,15 @@ class CodeGuardConfig:
             "max_cyclomatic_complexity": self.max_cyclomatic_complexity,
             "max_line_length": self.max_line_length,
             "max_function_lines": self.max_function_lines,
-            "check_pep8": self.check_pep8,
-            "check_pylint": self.check_pylint,
-            "check_security": self.check_security,
-            "check_complexity": self.check_complexity,
-            "check_types": self.check_types,
-            "check_imports": self.check_imports,
             "exclude_patterns": self.exclude_patterns,
+            "checks": {
+                "pep8": self.checks.pep8,
+                "pylint": self.checks.pylint,
+                "security": self.checks.security,
+                "complexity": self.checks.complexity,
+                "types": self.checks.types,
+                "imports": self.checks.imports,
+            },
             "ai": {
                 "enabled": self.ai.enabled,
                 "explain_errors": self.ai.explain_errors,

--- a/src/quality_agents/codeguard/formatter.py
+++ b/src/quality_agents/codeguard/formatter.py
@@ -58,16 +58,16 @@ def format_results(
     warnings = [r for r in results if r.severity == Severity.WARNING]
     infos = [r for r in results if r.severity == Severity.INFO]
 
-    # Mostrar resultados agrupados por paquete
-    by_package = _group_by_package(results)
-    for pkg_name in sorted(by_package.keys()):
-        pkg_results = by_package[pkg_name]
-        console.print(Rule(f"📦  {pkg_name}  ({len(pkg_results)} issues)", style="cyan"))
+    # Mostrar resultados agrupados por módulo
+    by_module = _group_by_module(results)
+    for module_name in sorted(by_module.keys()):
+        mod_results = by_module[module_name]
+        console.print(Rule(f"📄  {module_name}  ({len(mod_results)} issues)", style="cyan"))
         console.print()
 
-        pkg_errors = [r for r in pkg_results if r.severity == Severity.ERROR]
-        pkg_warnings = [r for r in pkg_results if r.severity == Severity.WARNING]
-        pkg_infos = [r for r in pkg_results if r.severity == Severity.INFO]
+        pkg_errors = [r for r in mod_results if r.severity == Severity.ERROR]
+        pkg_warnings = [r for r in mod_results if r.severity == Severity.WARNING]
+        pkg_infos = [r for r in mod_results if r.severity == Severity.INFO]
 
         if pkg_errors:
             _print_results_table(console, pkg_errors, "Errores", "red")
@@ -80,19 +80,18 @@ def format_results(
     _print_summary(console, errors, warnings, infos)
 
 
-def _package_name(file_path: Optional[str]) -> str:
-    """Extrae el nombre del paquete (directorio padre) del file_path."""
+def _module_name(file_path: Optional[str]) -> str:
+    """Extrae el nombre del módulo (.py) del file_path."""
     if not file_path:
         return "(sin archivo)"
-    parent = Path(file_path).parent
-    return parent.name or "."
+    return Path(file_path).name or file_path
 
 
-def _group_by_package(results: List[CheckResult]) -> Dict[str, List[CheckResult]]:
-    """Agrupa resultados por paquete (directorio padre del archivo)."""
+def _group_by_module(results: List[CheckResult]) -> Dict[str, List[CheckResult]]:
+    """Agrupa resultados por módulo (nombre del archivo .py)."""
     groups: Dict[str, List[CheckResult]] = defaultdict(list)
     for r in results:
-        groups[_package_name(r.file_path)].append(r)
+        groups[_module_name(r.file_path)].append(r)
     return dict(groups)
 
 
@@ -332,10 +331,10 @@ def format_json(
             "infos": [_r_to_dict(r) for r in infos],
         }
 
-        by_pkg = _group_by_package(results)
-        output["by_package"] = {
-            pkg: [_r_to_dict(r) for r in pkg_results]
-            for pkg, pkg_results in sorted(by_pkg.items())
+        by_mod = _group_by_module(results)
+        output["by_module"] = {
+            mod: [_r_to_dict(r) for r in mod_results]
+            for mod, mod_results in sorted(by_mod.items())
         }
 
     return json.dumps(output, indent=2, ensure_ascii=False)

--- a/src/quality_agents/codeguard/formatter.py
+++ b/src/quality_agents/codeguard/formatter.py
@@ -81,10 +81,12 @@ def format_results(
 
 
 def _module_name(file_path: Optional[str]) -> str:
-    """Extrae el nombre del módulo (.py) del file_path."""
+    """Retorna 'directorio/archivo.py' para identificar el módulo unívocamente."""
     if not file_path:
         return "(sin archivo)"
-    return Path(file_path).name or file_path
+    p = Path(file_path)
+    parent = p.parent.name
+    return f"{parent}/{p.name}" if parent and parent != "." else p.name
 
 
 def _group_by_module(results: List[CheckResult]) -> Dict[str, List[CheckResult]]:

--- a/src/quality_agents/designreviewer/analyzers/cbo_analyzer.py
+++ b/src/quality_agents/designreviewer/analyzers/cbo_analyzer.py
@@ -75,6 +75,8 @@ class CBOAnalyzer(Verifiable):
 
     def should_run(self, context: ExecutionContext) -> bool:
         self._config = context.config
+        if context.config and hasattr(context.config, "checks") and not getattr(context.config.checks, "cbo", True):
+            return False
         return not context.is_excluded and context.file_path.suffix == ".py"
 
     def execute(self, file_path: Path) -> List[ReviewResult]:

--- a/src/quality_agents/designreviewer/analyzers/circular_imports_analyzer.py
+++ b/src/quality_agents/designreviewer/analyzers/circular_imports_analyzer.py
@@ -55,6 +55,8 @@ class CircularImportsAnalyzer(Verifiable):
 
     def should_run(self, context: ExecutionContext) -> bool:
         self._config = context.config
+        if context.config and hasattr(context.config, "checks") and not getattr(context.config.checks, "circular_imports", True):
+            return False
         return not context.is_excluded and context.file_path.suffix == ".py"
 
     def execute(self, file_path: Path) -> List[ReviewResult]:

--- a/src/quality_agents/designreviewer/analyzers/data_clumps_analyzer.py
+++ b/src/quality_agents/designreviewer/analyzers/data_clumps_analyzer.py
@@ -69,6 +69,8 @@ class DataClumpsAnalyzer(Verifiable):
 
     def should_run(self, context: ExecutionContext) -> bool:
         self._config = context.config
+        if context.config and hasattr(context.config, "checks") and not getattr(context.config.checks, "data_clumps", True):
+            return False
         return not context.is_excluded and context.file_path.suffix == ".py"
 
     def execute(self, file_path: Path) -> List[ReviewResult]:

--- a/src/quality_agents/designreviewer/analyzers/dit_analyzer.py
+++ b/src/quality_agents/designreviewer/analyzers/dit_analyzer.py
@@ -59,6 +59,8 @@ class DITAnalyzer(Verifiable):
 
     def should_run(self, context: ExecutionContext) -> bool:
         self._config = context.config
+        if context.config and hasattr(context.config, "checks") and not getattr(context.config.checks, "dit", True):
+            return False
         return not context.is_excluded and context.file_path.suffix == ".py"
 
     def execute(self, file_path: Path) -> List[ReviewResult]:

--- a/src/quality_agents/designreviewer/analyzers/fan_out_analyzer.py
+++ b/src/quality_agents/designreviewer/analyzers/fan_out_analyzer.py
@@ -50,6 +50,8 @@ class FanOutAnalyzer(Verifiable):
 
     def should_run(self, context: ExecutionContext) -> bool:
         self._config = context.config
+        if context.config and hasattr(context.config, "checks") and not getattr(context.config.checks, "fan_out", True):
+            return False
         return not context.is_excluded and context.file_path.suffix == ".py"
 
     def execute(self, file_path: Path) -> List[ReviewResult]:

--- a/src/quality_agents/designreviewer/analyzers/feature_envy_analyzer.py
+++ b/src/quality_agents/designreviewer/analyzers/feature_envy_analyzer.py
@@ -74,6 +74,8 @@ class FeatureEnvyAnalyzer(Verifiable):
 
     def should_run(self, context: ExecutionContext) -> bool:
         self._config = context.config
+        if context.config and hasattr(context.config, "checks") and not getattr(context.config.checks, "feature_envy", True):
+            return False
         return not context.is_excluded and context.file_path.suffix == ".py"
 
     def execute(self, file_path: Path) -> List[ReviewResult]:

--- a/src/quality_agents/designreviewer/analyzers/god_object_analyzer.py
+++ b/src/quality_agents/designreviewer/analyzers/god_object_analyzer.py
@@ -56,6 +56,8 @@ class GodObjectAnalyzer(Verifiable):
 
     def should_run(self, context: ExecutionContext) -> bool:
         self._config = context.config
+        if context.config and hasattr(context.config, "checks") and not getattr(context.config.checks, "god_object", True):
+            return False
         return not context.is_excluded and context.file_path.suffix == ".py"
 
     def execute(self, file_path: Path) -> List[ReviewResult]:

--- a/src/quality_agents/designreviewer/analyzers/lcom_analyzer.py
+++ b/src/quality_agents/designreviewer/analyzers/lcom_analyzer.py
@@ -63,6 +63,8 @@ class LCOMAnalyzer(Verifiable):
 
     def should_run(self, context: ExecutionContext) -> bool:
         self._config = context.config
+        if context.config and hasattr(context.config, "checks") and not getattr(context.config.checks, "lcom", True):
+            return False
         return not context.is_excluded and context.file_path.suffix == ".py"
 
     def execute(self, file_path: Path) -> List[ReviewResult]:

--- a/src/quality_agents/designreviewer/analyzers/long_method_analyzer.py
+++ b/src/quality_agents/designreviewer/analyzers/long_method_analyzer.py
@@ -55,6 +55,8 @@ class LongMethodAnalyzer(Verifiable):
 
     def should_run(self, context: ExecutionContext) -> bool:
         self._config = context.config
+        if context.config and hasattr(context.config, "checks") and not getattr(context.config.checks, "long_method", True):
+            return False
         return not context.is_excluded and context.file_path.suffix == ".py"
 
     def execute(self, file_path: Path) -> List[ReviewResult]:

--- a/src/quality_agents/designreviewer/analyzers/long_parameter_list_analyzer.py
+++ b/src/quality_agents/designreviewer/analyzers/long_parameter_list_analyzer.py
@@ -62,6 +62,8 @@ class LongParameterListAnalyzer(Verifiable):
 
     def should_run(self, context: ExecutionContext) -> bool:
         self._config = context.config
+        if context.config and hasattr(context.config, "checks") and not getattr(context.config.checks, "long_parameter_list", True):
+            return False
         return not context.is_excluded and context.file_path.suffix == ".py"
 
     def execute(self, file_path: Path) -> List[ReviewResult]:

--- a/src/quality_agents/designreviewer/analyzers/nop_analyzer.py
+++ b/src/quality_agents/designreviewer/analyzers/nop_analyzer.py
@@ -59,6 +59,8 @@ class NOPAnalyzer(Verifiable):
 
     def should_run(self, context: ExecutionContext) -> bool:
         self._config = context.config
+        if context.config and hasattr(context.config, "checks") and not getattr(context.config.checks, "nop", True):
+            return False
         return not context.is_excluded and context.file_path.suffix == ".py"
 
     def execute(self, file_path: Path) -> List[ReviewResult]:

--- a/src/quality_agents/designreviewer/analyzers/wmc_analyzer.py
+++ b/src/quality_agents/designreviewer/analyzers/wmc_analyzer.py
@@ -62,6 +62,8 @@ class WMCAnalyzer(Verifiable):
 
     def should_run(self, context: ExecutionContext) -> bool:
         self._config = context.config
+        if context.config and hasattr(context.config, "checks") and not context.config.checks.wmc:
+            return False
         return (
             _RADON_DISPONIBLE
             and not context.is_excluded

--- a/src/quality_agents/designreviewer/config.py
+++ b/src/quality_agents/designreviewer/config.py
@@ -43,6 +43,41 @@ class AIConfig:
 
 
 @dataclass
+class DesignReviewerChecksConfig:
+    """
+    Toggles para habilitar/deshabilitar analyzers individuales de DesignReviewer.
+
+    Configurable desde pyproject.toml con la sección [tool.designreviewer.checks].
+
+    Example::
+
+        [tool.designreviewer.checks]
+        cbo = false
+        lcom = true
+    """
+
+    # Acoplamiento
+    cbo: bool = True
+    fan_out: bool = True
+    circular_imports: bool = True
+
+    # Cohesión y complejidad
+    lcom: bool = True
+    wmc: bool = True
+
+    # Herencia
+    dit: bool = True
+    nop: bool = True
+
+    # Code smells
+    god_object: bool = True
+    long_method: bool = True
+    long_parameter_list: bool = True
+    feature_envy: bool = True
+    data_clumps: bool = True
+
+
+@dataclass
 class DesignReviewerConfig:
     """
     Configuración de DesignReviewer.
@@ -83,6 +118,9 @@ class DesignReviewerConfig:
         "conftest",
     ])
 
+    # Toggles de analyzers
+    checks: DesignReviewerChecksConfig = field(default_factory=DesignReviewerChecksConfig)
+
     # Configuración de IA
     ai: AIConfig = field(default_factory=AIConfig)
 
@@ -120,12 +158,18 @@ class DesignReviewerConfig:
         if not tool_config:
             return cls()
 
-        # Extraer sub-sección de IA
+        # Extraer sub-secciones antes de pasar el resto al dataclass
         ai_data = tool_config.pop("ai", {})
+        checks_data = tool_config.pop("checks", {})
         ai_config = AIConfig(**_filter_fields(AIConfig, ai_data)) if ai_data else AIConfig()
+        checks_config = (
+            DesignReviewerChecksConfig(**_filter_fields(DesignReviewerChecksConfig, checks_data))
+            if checks_data else DesignReviewerChecksConfig()
+        )
 
         config = cls(**_filter_fields(cls, tool_config))
         config.ai = ai_config
+        config.checks = checks_config
         return config
 
 

--- a/src/quality_agents/designreviewer/formatter.py
+++ b/src/quality_agents/designreviewer/formatter.py
@@ -54,39 +54,38 @@ def format_results(
     warnings = [r for r in results if r.severity == ReviewSeverity.WARNING]
     infos = [r for r in results if r.severity == ReviewSeverity.INFO]
 
-    # Mostrar resultados agrupados por paquete
-    by_package = _group_by_package(results)
-    for pkg_name in sorted(by_package.keys()):
-        pkg_results = by_package[pkg_name]
-        console.print(Rule(f"📦  {pkg_name}  ({len(pkg_results)} issues)", style="cyan"))
+    # Mostrar resultados agrupados por módulo
+    by_module = _group_by_module(results)
+    for module_name in sorted(by_module.keys()):
+        mod_results = by_module[module_name]
+        console.print(Rule(f"📄  {module_name}  ({len(mod_results)} issues)", style="cyan"))
         console.print()
 
-        pkg_criticals = [r for r in pkg_results if r.severity == ReviewSeverity.CRITICAL]
-        pkg_warnings = [r for r in pkg_results if r.severity == ReviewSeverity.WARNING]
-        pkg_infos = [r for r in pkg_results if r.severity == ReviewSeverity.INFO]
+        mod_criticals = [r for r in mod_results if r.severity == ReviewSeverity.CRITICAL]
+        mod_warnings = [r for r in mod_results if r.severity == ReviewSeverity.WARNING]
+        mod_infos = [r for r in mod_results if r.severity == ReviewSeverity.INFO]
 
-        if pkg_criticals:
-            _print_blocking_issues(console, pkg_criticals)
-        if pkg_warnings:
-            _print_results_table(console, pkg_warnings, "Advertencias de Diseño", "yellow")
-        if pkg_infos:
-            _print_results_table(console, pkg_infos, "Informativos", "blue")
+        if mod_criticals:
+            _print_blocking_issues(console, mod_criticals)
+        if mod_warnings:
+            _print_results_table(console, mod_warnings, "Advertencias de Diseño", "yellow")
+        if mod_infos:
+            _print_results_table(console, mod_infos, "Informativos", "blue")
 
     _print_summary(console, criticals, warnings, infos)
     _print_effort_summary(console, results)
 
 
-def _package_name(r: "ReviewResult") -> str:
-    """Extrae el nombre del paquete (directorio padre) del file_path."""
-    parent = r.file_path.parent
-    return parent.name or "."
+def _module_name(r: "ReviewResult") -> str:
+    """Extrae el nombre del módulo (.py) del file_path."""
+    return r.file_path.name
 
 
-def _group_by_package(results: List[ReviewResult]) -> Dict[str, List[ReviewResult]]:
-    """Agrupa resultados por paquete (directorio padre del archivo)."""
+def _group_by_module(results: List[ReviewResult]) -> Dict[str, List[ReviewResult]]:
+    """Agrupa resultados por módulo (nombre del archivo .py)."""
     groups: Dict[str, List[ReviewResult]] = defaultdict(list)
     for r in results:
-        groups[_package_name(r)].append(r)
+        groups[_module_name(r)].append(r)
     return dict(groups)
 
 
@@ -271,7 +270,7 @@ def format_json(
     total_effort = sum(r.estimated_effort for r in results)
     critical_effort = sum(r.estimated_effort for r in criticals)
 
-    by_pkg = _group_by_package(results)
+    by_mod = _group_by_module(results)
 
     output: Dict[str, Any] = {
         "summary": {
@@ -295,9 +294,9 @@ def format_json(
             "warning": [_result_to_dict(r) for r in warnings],
             "info": [_result_to_dict(r) for r in infos],
         },
-        "by_package": {
-            pkg: [_result_to_dict(r) for r in pkg_results]
-            for pkg, pkg_results in sorted(by_pkg.items())
+        "by_module": {
+            mod: [_result_to_dict(r) for r in mod_results]
+            for mod, mod_results in sorted(by_mod.items())
         },
     }
 

--- a/src/quality_agents/designreviewer/formatter.py
+++ b/src/quality_agents/designreviewer/formatter.py
@@ -77,8 +77,10 @@ def format_results(
 
 
 def _module_name(r: "ReviewResult") -> str:
-    """Extrae el nombre del módulo (.py) del file_path."""
-    return r.file_path.name
+    """Retorna 'directorio/archivo.py' para identificar el módulo unívocamente."""
+    p = r.file_path
+    parent = p.parent.name
+    return f"{parent}/{p.name}" if parent and parent != "." else p.name
 
 
 def _group_by_module(results: List[ReviewResult]) -> Dict[str, List[ReviewResult]]:

--- a/tests/e2e/test_codeguard_e2e.py
+++ b/tests/e2e/test_codeguard_e2e.py
@@ -70,10 +70,12 @@ class TestCodeGuardCLIEndToEnd:
                 [tool.codeguard]
                 min_pylint_score = 8.0
                 max_cyclomatic_complexity = 10
-                check_pep8 = true
-                check_pylint = true
-                check_security = true
                 exclude_patterns = ["test_", "__pycache__"]
+
+                [tool.codeguard.checks]
+                pep8 = true
+                pylint = true
+                security = true
 
                 [tool.codeguard.ai]
                 enabled = false

--- a/tests/integration/test_codeguard_integration.py
+++ b/tests/integration/test_codeguard_integration.py
@@ -364,9 +364,11 @@ class TestCodeGuardWithConfiguration:
 [tool.codeguard]
 min_pylint_score = 9.0
 max_cyclomatic_complexity = 5
-check_pep8 = true
-check_security = true
 exclude_patterns = ["test_*.py", "__pycache__"]
+
+[tool.codeguard.checks]
+pep8 = true
+security = true
 
 [tool.codeguard.ai]
 enabled = false
@@ -393,11 +395,12 @@ enabled = false
         yaml_config.write_text("""
 min_pylint_score: 8.5
 max_cyclomatic_complexity: 8
-check_pep8: true
-check_security: true
 exclude_patterns:
   - "*.pyc"
   - "__pycache__"
+checks:
+  pep8: true
+  security: true
 """)
 
         # Crear archivo Python
@@ -416,8 +419,8 @@ exclude_patterns:
         # Verificar que cargó la configuración
         assert config.min_pylint_score == 9.0
         assert config.max_cyclomatic_complexity == 5
-        assert config.check_pep8 is True
-        assert config.check_security is True
+        assert config.checks.pep8 is True
+        assert config.checks.security is True
         assert "test_*.py" in config.exclude_patterns
         assert config.ai.enabled is False
 
@@ -432,8 +435,8 @@ exclude_patterns:
         # Verificar que cargó la configuración
         assert config.min_pylint_score == 8.5
         assert config.max_cyclomatic_complexity == 8
-        assert config.check_pep8 is True
-        assert config.check_security is True
+        assert config.checks.pep8 is True
+        assert config.checks.security is True
 
     def test_load_config_defaults_when_no_file(self):
         """Verifica que usa defaults cuando no hay archivo de configuración."""

--- a/tests/integration/test_pre_commit_hooks.py
+++ b/tests/integration/test_pre_commit_hooks.py
@@ -106,13 +106,13 @@ class TestPreCommitHooksConfiguration:
             )
 
     def test_example_config_file_exists(self):
-        """Debe existir un archivo de ejemplo .pre-commit-config.yaml.example."""
-        example_file = PROJECT_ROOT / ".pre-commit-config.yaml.example"
-        assert example_file.exists(), ".pre-commit-config.yaml.example not found"
+        """Debe existir un archivo de ejemplo pre-commit-config.yaml.example en examples/."""
+        example_file = PROJECT_ROOT / "examples" / "pre-commit-config.yaml.example"
+        assert example_file.exists(), "examples/pre-commit-config.yaml.example not found"
 
     def test_example_config_is_valid_yaml(self):
         """El archivo de ejemplo debe ser YAML válido."""
-        example_file = PROJECT_ROOT / ".pre-commit-config.yaml.example"
+        example_file = PROJECT_ROOT / "examples" / "pre-commit-config.yaml.example"
         with open(example_file) as f:
             try:
                 yaml.safe_load(f)

--- a/tests/unit/test_architectanalyst_config.py
+++ b/tests/unit/test_architectanalyst_config.py
@@ -8,6 +8,7 @@ import pytest
 
 from quality_agents.architectanalyst.config import (
     AIConfig,
+    ArchitectAnalystChecksConfig,
     ArchitectAnalystConfig,
     LayersConfig,
     load_config,
@@ -35,6 +36,33 @@ class TestAIConfig:
         ai = AIConfig(max_tokens=2000)
 
         assert ai.max_tokens == 2000
+
+
+class TestArchitectAnalystChecksConfig:
+    """Tests para ArchitectAnalystChecksConfig (#62)."""
+
+    def test_defaults(self):
+        """Todas las métricas deben estar habilitadas por defecto."""
+        checks = ArchitectAnalystChecksConfig()
+        assert checks.coupling is True
+        assert checks.abstractness is True
+        assert checks.instability is True
+        assert checks.distance is True
+        assert checks.dependency_cycles is True
+        assert checks.layer_violations is True
+
+    def test_from_pyproject_toml(self, tmp_path):
+        """Debe leer toggles desde [tool.architectanalyst.checks]."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text("""
+[tool.architectanalyst.checks]
+distance = false
+layer_violations = false
+""")
+        config = ArchitectAnalystConfig.from_pyproject_toml(pyproject)
+        assert config.checks.distance is False
+        assert config.checks.layer_violations is False
+        assert config.checks.coupling is True  # default
 
 
 class TestLayersConfig:

--- a/tests/unit/test_codeguard_config.py
+++ b/tests/unit/test_codeguard_config.py
@@ -5,7 +5,47 @@ Tests unitarios para configuración de CodeGuard.
 
 import pytest
 
-from quality_agents.codeguard.config import AIConfig, CodeGuardConfig, load_config
+from quality_agents.codeguard.config import AIConfig, ChecksConfig, CodeGuardConfig, load_config
+
+
+class TestChecksConfig:
+    """Tests para ChecksConfig (#60)."""
+
+    def test_default_values(self):
+        """Todos los checks deben estar habilitados por defecto."""
+        checks = ChecksConfig()
+        assert checks.pep8 is True
+        assert checks.pylint is True
+        assert checks.security is True
+        assert checks.complexity is True
+        assert checks.types is True
+        assert checks.imports is True
+
+    def test_from_pyproject_toml(self, tmp_path):
+        """Debe leer toggles desde [tool.codeguard.checks]."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text("""
+[tool.codeguard.checks]
+pep8 = false
+security = false
+""")
+        config = CodeGuardConfig.from_pyproject_toml(pyproject)
+        assert config.checks.pep8 is False
+        assert config.checks.security is False
+        assert config.checks.pylint is True   # no tocado, debe ser default
+
+    def test_from_yaml(self, tmp_path):
+        """Debe leer toggles desde sección checks en YAML."""
+        yml = tmp_path / "config.yml"
+        yml.write_text("""
+checks:
+  types: false
+  imports: false
+""")
+        config = CodeGuardConfig.from_yaml(yml)
+        assert config.checks.types is False
+        assert config.checks.imports is False
+        assert config.checks.pep8 is True   # no tocado, debe ser default
 
 
 class TestAIConfig:
@@ -48,12 +88,13 @@ class TestCodeGuardConfig:
         assert config.max_function_lines == 20
 
         # Checks
-        assert config.check_pep8 is True
-        assert config.check_pylint is True
-        assert config.check_security is True
-        assert config.check_complexity is True
-        assert config.check_types is True
-        assert config.check_imports is True
+        assert isinstance(config.checks, ChecksConfig)
+        assert config.checks.pep8 is True
+        assert config.checks.pylint is True
+        assert config.checks.security is True
+        assert config.checks.complexity is True
+        assert config.checks.types is True
+        assert config.checks.imports is True
 
         # Exclusiones
         assert "__pycache__" in config.exclude_patterns
@@ -70,17 +111,19 @@ class TestCodeGuardConfig:
 [tool.codeguard]
 min_pylint_score = 7.5
 max_cyclomatic_complexity = 15
-check_pep8 = false
-check_security = true
 exclude_patterns = ["tests/*", "migrations/*"]
+
+[tool.codeguard.checks]
+pep8 = false
+security = true
 """)
 
         config = CodeGuardConfig.from_pyproject_toml(pyproject)
 
         assert config.min_pylint_score == 7.5
         assert config.max_cyclomatic_complexity == 15
-        assert config.check_pep8 is False
-        assert config.check_security is True
+        assert config.checks.pep8 is False
+        assert config.checks.security is True
         assert "tests/*" in config.exclude_patterns
         assert "migrations/*" in config.exclude_patterns
 
@@ -133,19 +176,20 @@ something = "value"
         config_file.write_text("""
 min_pylint_score: 7.0
 max_cyclomatic_complexity: 12
-check_pep8: true
-check_security: false
 exclude_patterns:
   - "*.pyc"
   - "build/*"
+checks:
+  pep8: true
+  security: false
 """)
 
         config = CodeGuardConfig.from_yaml(config_file)
 
         assert config.min_pylint_score == 7.0
         assert config.max_cyclomatic_complexity == 12
-        assert config.check_pep8 is True
-        assert config.check_security is False
+        assert config.checks.pep8 is True
+        assert config.checks.security is False
         assert "build/*" in config.exclude_patterns
 
     def test_from_yaml_with_ai(self, tmp_path):
@@ -216,7 +260,7 @@ check_hexagonal = true
         """Debe guardar configuración a YAML correctamente."""
         config = CodeGuardConfig(
             min_pylint_score=7.5,
-            check_pep8=False,
+            checks=ChecksConfig(pep8=False),
         )
         config.ai.enabled = True
 
@@ -228,7 +272,7 @@ check_hexagonal = true
         # Leer de vuelta para verificar
         config_loaded = CodeGuardConfig.from_yaml(output_file)
         assert config_loaded.min_pylint_score == 7.5
-        assert config_loaded.check_pep8 is False
+        assert config_loaded.checks.pep8 is False
         assert config_loaded.ai.enabled is True
 
 
@@ -241,26 +285,29 @@ class TestLoadConfig:
         config_file.write_text("""
 [tool.codeguard]
 min_pylint_score = 9.0
-check_pep8 = false
+
+[tool.codeguard.checks]
+pep8 = false
 """)
 
         config = load_config(config_path=config_file)
 
         assert config.min_pylint_score == 9.0
-        assert config.check_pep8 is False
+        assert config.checks.pep8 is False
 
     def test_load_config_explicit_path_yaml(self, tmp_path):
         """Debe cargar desde path explícito (YAML)."""
         config_file = tmp_path / "custom.yml"
         config_file.write_text("""
 min_pylint_score: 6.5
-check_security: false
+checks:
+  security: false
 """)
 
         config = load_config(config_path=config_file)
 
         assert config.min_pylint_score == 6.5
-        assert config.check_security is False
+        assert config.checks.security is False
 
     def test_load_config_explicit_path_not_found(self, tmp_path):
         """Debe retornar defaults si path explícito no existe."""
@@ -270,7 +317,7 @@ check_security: false
 
         # Debe retornar defaults
         assert config.min_pylint_score == 8.0
-        assert config.check_pep8 is True
+        assert config.checks.pep8 is True
 
     def test_load_config_from_pyproject_toml(self, tmp_path):
         """Debe auto-descubrir pyproject.toml en project_root."""
@@ -297,13 +344,14 @@ max_tokens = 600
         yml_file = tmp_path / ".codeguard.yml"
         yml_file.write_text("""
 min_pylint_score: 6.0
-check_types: false
+checks:
+  types: false
 """)
 
         config = load_config(project_root=tmp_path)
 
         assert config.min_pylint_score == 6.0
-        assert config.check_types is False
+        assert config.checks.types is False
 
     def test_load_config_pyproject_toml_priority_over_yml(self, tmp_path):
         """pyproject.toml debe tener prioridad sobre .codeguard.yml."""
@@ -332,7 +380,7 @@ min_pylint_score: 5.0
 
         # Debe retornar todos los defaults
         assert config.min_pylint_score == 8.0
-        assert config.check_pep8 is True
+        assert config.checks.pep8 is True
         assert config.ai.enabled is False
 
     def test_load_config_default_project_root(self):

--- a/tests/unit/test_complexity_check.py
+++ b/tests/unit/test_complexity_check.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock, patch
 
 from quality_agents.codeguard.agent import Severity
 from quality_agents.codeguard.checks.complexity_check import ComplexityCheck
-from quality_agents.codeguard.config import CodeGuardConfig
+from quality_agents.codeguard.config import ChecksConfig, CodeGuardConfig
 from quality_agents.shared.verifiable import ExecutionContext
 
 
@@ -43,7 +43,7 @@ class TestComplexityCheckShouldRun:
         context = ExecutionContext(
             file_path=Path("test.py"),
             is_excluded=False,
-            config=CodeGuardConfig(check_complexity=True),
+            config=CodeGuardConfig(checks=ChecksConfig(complexity=True)),
         )
         assert check.should_run(context) is True
 
@@ -52,7 +52,7 @@ class TestComplexityCheckShouldRun:
         context = ExecutionContext(
             file_path=Path("test.py"),
             is_excluded=True,
-            config=CodeGuardConfig(check_complexity=True),
+            config=CodeGuardConfig(checks=ChecksConfig(complexity=True)),
         )
         assert check.should_run(context) is False
 
@@ -61,7 +61,7 @@ class TestComplexityCheckShouldRun:
         context = ExecutionContext(
             file_path=Path("test.txt"),
             is_excluded=False,
-            config=CodeGuardConfig(check_complexity=True),
+            config=CodeGuardConfig(checks=ChecksConfig(complexity=True)),
         )
         assert check.should_run(context) is False
 
@@ -70,7 +70,7 @@ class TestComplexityCheckShouldRun:
         context = ExecutionContext(
             file_path=Path("test.py"),
             is_excluded=False,
-            config=CodeGuardConfig(check_complexity=False),
+            config=CodeGuardConfig(checks=ChecksConfig(complexity=False)),
         )
         assert check.should_run(context) is False
 

--- a/tests/unit/test_designreviewer_config.py
+++ b/tests/unit/test_designreviewer_config.py
@@ -7,7 +7,12 @@ Ticket: 1.7
 
 import pytest
 
-from quality_agents.designreviewer.config import AIConfig, DesignReviewerConfig, load_config
+from quality_agents.designreviewer.config import (
+    AIConfig,
+    DesignReviewerChecksConfig,
+    DesignReviewerConfig,
+    load_config,
+)
 
 
 class TestAIConfig:
@@ -26,6 +31,39 @@ class TestAIConfig:
         ai = AIConfig(enabled=True)
 
         assert ai.enabled is True
+
+
+class TestDesignReviewerChecksConfig:
+    """Tests para DesignReviewerChecksConfig (#61)."""
+
+    def test_defaults(self):
+        """Todos los analyzers deben estar habilitados por defecto."""
+        checks = DesignReviewerChecksConfig()
+        assert checks.cbo is True
+        assert checks.fan_out is True
+        assert checks.circular_imports is True
+        assert checks.lcom is True
+        assert checks.wmc is True
+        assert checks.dit is True
+        assert checks.nop is True
+        assert checks.god_object is True
+        assert checks.long_method is True
+        assert checks.long_parameter_list is True
+        assert checks.feature_envy is True
+        assert checks.data_clumps is True
+
+    def test_from_pyproject_toml(self, tmp_path):
+        """Debe leer toggles desde [tool.designreviewer.checks]."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text("""
+[tool.designreviewer.checks]
+cbo = false
+lcom = false
+""")
+        config = DesignReviewerConfig.from_pyproject_toml(pyproject)
+        assert config.checks.cbo is False
+        assert config.checks.lcom is False
+        assert config.checks.fan_out is True  # default
 
 
 class TestDesignReviewerConfig:

--- a/tests/unit/test_designreviewer_formatter.py
+++ b/tests/unit/test_designreviewer_formatter.py
@@ -194,7 +194,7 @@ class TestFormatJson:
         json.loads(output)  # no debe lanzar excepción
 
     def test_json_incluye_by_module(self):
-        """JSON debe incluir sección by_module (#56)."""
+        """JSON debe incluir sección by_module con clave directorio/archivo (#56)."""
         results = [
             ReviewResult(
                 analyzer_name="CBO",
@@ -215,8 +215,8 @@ class TestFormatJson:
         ]
         data = json.loads(format_json(results, elapsed=1.0, total_files=2, analyzers_executed=8))
         assert "by_module" in data
-        assert "user_service.py" in data["by_module"]
-        assert "pedido.py" in data["by_module"]
+        assert "servicios/user_service.py" in data["by_module"]
+        assert "entidades/pedido.py" in data["by_module"]
 
     def test_json_by_module_mismo_archivo(self):
         """Resultados del mismo archivo deben agruparse (#56)."""
@@ -239,7 +239,7 @@ class TestFormatJson:
             ),
         ]
         data = json.loads(format_json(results, elapsed=1.0, total_files=2, analyzers_executed=8))
-        assert len(data["by_module"]["servicio.py"]) == 2
+        assert len(data["by_module"]["servicios/servicio.py"]) == 2
 
     def test_json_by_module_archivos_distintos(self):
         """Archivos distintos del mismo directorio tienen entradas separadas (#56)."""
@@ -262,15 +262,15 @@ class TestFormatJson:
             ),
         ]
         data = json.loads(format_json(results, elapsed=1.0, total_files=2, analyzers_executed=8))
-        assert "a.py" in data["by_module"]
-        assert "b.py" in data["by_module"]
+        assert "servicios/a.py" in data["by_module"]
+        assert "servicios/b.py" in data["by_module"]
 
 
 class TestFormatResultsByModule:
     """Tests de agrupación por módulo en salida text (#56)."""
 
     def test_muestra_header_de_modulo(self, capsys):
-        """La salida text debe mostrar encabezado con nombre del módulo."""
+        """La salida text debe mostrar encabezado con directorio/módulo."""
         results = [
             ReviewResult(
                 analyzer_name="CBO",
@@ -283,7 +283,7 @@ class TestFormatResultsByModule:
         ]
         format_results(results, elapsed=0.1, total_files=1, analyzers_executed=8)
         out = capsys.readouterr().out
-        assert "servicio.py" in out
+        assert "mipaquete/servicio.py" in out
 
     def test_agrupa_dos_modulos(self, capsys):
         """Archivos distintos deben mostrar dos encabezados."""
@@ -307,5 +307,5 @@ class TestFormatResultsByModule:
         ]
         format_results(results, elapsed=0.1, total_files=2, analyzers_executed=8)
         out = capsys.readouterr().out
-        assert "pedido.py" in out
-        assert "user.py" in out
+        assert "entidades/pedido.py" in out
+        assert "servicios/user.py" in out

--- a/tests/unit/test_designreviewer_formatter.py
+++ b/tests/unit/test_designreviewer_formatter.py
@@ -193,8 +193,8 @@ class TestFormatJson:
         assert len(output) > 0
         json.loads(output)  # no debe lanzar excepción
 
-    def test_json_incluye_by_package(self):
-        """JSON debe incluir sección by_package (fix #40)."""
+    def test_json_incluye_by_module(self):
+        """JSON debe incluir sección by_module (#56)."""
         results = [
             ReviewResult(
                 analyzer_name="CBO",
@@ -214,12 +214,35 @@ class TestFormatJson:
             ),
         ]
         data = json.loads(format_json(results, elapsed=1.0, total_files=2, analyzers_executed=8))
-        assert "by_package" in data
-        assert "servicios" in data["by_package"]
-        assert "entidades" in data["by_package"]
+        assert "by_module" in data
+        assert "user_service.py" in data["by_module"]
+        assert "pedido.py" in data["by_module"]
 
-    def test_json_by_package_agrupa_mismo_directorio(self):
-        """Archivos del mismo directorio deben agruparse (fix #40)."""
+    def test_json_by_module_mismo_archivo(self):
+        """Resultados del mismo archivo deben agruparse (#56)."""
+        results = [
+            ReviewResult(
+                analyzer_name="CBO",
+                severity=ReviewSeverity.WARNING,
+                current_value=8,
+                threshold=5,
+                message="msg",
+                file_path=Path("servicios/servicio.py"),
+            ),
+            ReviewResult(
+                analyzer_name="LCOM",
+                severity=ReviewSeverity.WARNING,
+                current_value=3,
+                threshold=1,
+                message="msg",
+                file_path=Path("servicios/servicio.py"),
+            ),
+        ]
+        data = json.loads(format_json(results, elapsed=1.0, total_files=2, analyzers_executed=8))
+        assert len(data["by_module"]["servicio.py"]) == 2
+
+    def test_json_by_module_archivos_distintos(self):
+        """Archivos distintos del mismo directorio tienen entradas separadas (#56)."""
         results = [
             ReviewResult(
                 analyzer_name="CBO",
@@ -239,14 +262,15 @@ class TestFormatJson:
             ),
         ]
         data = json.loads(format_json(results, elapsed=1.0, total_files=2, analyzers_executed=8))
-        assert len(data["by_package"]["servicios"]) == 2
+        assert "a.py" in data["by_module"]
+        assert "b.py" in data["by_module"]
 
 
-class TestFormatResultsByPackage:
-    """Tests de agrupación por paquete en salida text (fix #40)."""
+class TestFormatResultsByModule:
+    """Tests de agrupación por módulo en salida text (#56)."""
 
-    def test_muestra_header_de_paquete(self, capsys):
-        """La salida text debe mostrar encabezado con nombre del paquete."""
+    def test_muestra_header_de_modulo(self, capsys):
+        """La salida text debe mostrar encabezado con nombre del módulo."""
         results = [
             ReviewResult(
                 analyzer_name="CBO",
@@ -259,10 +283,10 @@ class TestFormatResultsByPackage:
         ]
         format_results(results, elapsed=0.1, total_files=1, analyzers_executed=8)
         out = capsys.readouterr().out
-        assert "mipaquete" in out
+        assert "servicio.py" in out
 
-    def test_agrupa_dos_paquetes(self, capsys):
-        """Archivos de distintos paquetes deben mostrar dos encabezados."""
+    def test_agrupa_dos_modulos(self, capsys):
+        """Archivos distintos deben mostrar dos encabezados."""
         results = [
             ReviewResult(
                 analyzer_name="CBO",
@@ -283,5 +307,5 @@ class TestFormatResultsByPackage:
         ]
         format_results(results, elapsed=0.1, total_files=2, analyzers_executed=8)
         out = capsys.readouterr().out
-        assert "entidades" in out
-        assert "servicios" in out
+        assert "pedido.py" in out
+        assert "user.py" in out

--- a/tests/unit/test_formatter.py
+++ b/tests/unit/test_formatter.py
@@ -468,45 +468,56 @@ class TestFormatJson:
         assert data["results"][0]["file"] is None
         assert data["results"][0]["line"] is None
 
-    def test_format_json_incluye_by_package(self):
-        """JSON debe incluir sección by_package (fix #37)."""
+    def test_format_json_incluye_by_module(self):
+        """JSON debe incluir sección by_module (#53)."""
         results = [
             CheckResult("PEP8", Severity.ERROR, "Line too long", "src/modulo.py", 10),
             CheckResult("Pylint", Severity.WARNING, "Low score", "lib/utils.py"),
         ]
         data = json.loads(format_json(results))
-        assert "by_package" in data
-        assert "src" in data["by_package"]
-        assert "lib" in data["by_package"]
-        assert len(data["by_package"]["src"]) == 1
-        assert len(data["by_package"]["lib"]) == 1
+        assert "by_module" in data
+        assert "modulo.py" in data["by_module"]
+        assert "utils.py" in data["by_module"]
+        assert len(data["by_module"]["modulo.py"]) == 1
+        assert len(data["by_module"]["utils.py"]) == 1
 
-    def test_format_json_by_package_mismo_directorio(self):
-        """Archivos del mismo directorio deben agruparse juntos (fix #37)."""
+    def test_format_json_by_module_mismo_archivo(self):
+        """Resultados del mismo archivo deben agruparse juntos (#53)."""
+        results = [
+            CheckResult("PEP8", Severity.ERROR, "msg1", "src/modulo.py"),
+            CheckResult("Pylint", Severity.WARNING, "msg2", "src/modulo.py"),
+        ]
+        data = json.loads(format_json(results))
+        assert "by_module" in data
+        assert len(data["by_module"]["modulo.py"]) == 2
+
+    def test_format_json_by_module_archivos_distintos(self):
+        """Archivos distintos del mismo directorio tienen entradas separadas (#53)."""
         results = [
             CheckResult("PEP8", Severity.ERROR, "msg1", "src/a.py"),
             CheckResult("Pylint", Severity.WARNING, "msg2", "src/b.py"),
         ]
         data = json.loads(format_json(results))
-        assert "by_package" in data
-        assert len(data["by_package"]["src"]) == 2
+        assert "by_module" in data
+        assert "a.py" in data["by_module"]
+        assert "b.py" in data["by_module"]
 
 
-class TestFormatResultsByPackage:
-    """Tests de agrupación por paquete en salida text (fix #37)."""
+class TestFormatResultsByModule:
+    """Tests de agrupación por módulo en salida text (#53)."""
 
-    def test_muestra_header_de_paquete(self, capsys):
-        """La salida text debe mostrar encabezado con nombre del paquete."""
+    def test_muestra_header_de_modulo(self, capsys):
+        """La salida text debe mostrar encabezado con nombre del módulo."""
         from quality_agents.codeguard.formatter import format_results as fmt
         results = [
             CheckResult("PEP8", Severity.ERROR, "msg", "mipaquete/modulo.py", 1),
         ]
         fmt(results, elapsed=0.1, total_files=1, checks_executed=3)
         out = capsys.readouterr().out
-        assert "mipaquete" in out
+        assert "modulo.py" in out
 
-    def test_agrupa_dos_paquetes(self, capsys):
-        """Archivos de distintos paquetes deben mostrar dos encabezados."""
+    def test_agrupa_dos_modulos(self, capsys):
+        """Archivos distintos deben mostrar dos encabezados."""
         from quality_agents.codeguard.formatter import format_results as fmt
         results = [
             CheckResult("PEP8", Severity.ERROR, "msg", "paquete_a/x.py", 1),
@@ -514,5 +525,5 @@ class TestFormatResultsByPackage:
         ]
         fmt(results, elapsed=0.1, total_files=2, checks_executed=3)
         out = capsys.readouterr().out
-        assert "paquete_a" in out
-        assert "paquete_b" in out
+        assert "x.py" in out
+        assert "y.py" in out

--- a/tests/unit/test_formatter.py
+++ b/tests/unit/test_formatter.py
@@ -469,17 +469,17 @@ class TestFormatJson:
         assert data["results"][0]["line"] is None
 
     def test_format_json_incluye_by_module(self):
-        """JSON debe incluir sección by_module (#53)."""
+        """JSON debe incluir sección by_module con clave directorio/archivo (#53)."""
         results = [
             CheckResult("PEP8", Severity.ERROR, "Line too long", "src/modulo.py", 10),
             CheckResult("Pylint", Severity.WARNING, "Low score", "lib/utils.py"),
         ]
         data = json.loads(format_json(results))
         assert "by_module" in data
-        assert "modulo.py" in data["by_module"]
-        assert "utils.py" in data["by_module"]
-        assert len(data["by_module"]["modulo.py"]) == 1
-        assert len(data["by_module"]["utils.py"]) == 1
+        assert "src/modulo.py" in data["by_module"]
+        assert "lib/utils.py" in data["by_module"]
+        assert len(data["by_module"]["src/modulo.py"]) == 1
+        assert len(data["by_module"]["lib/utils.py"]) == 1
 
     def test_format_json_by_module_mismo_archivo(self):
         """Resultados del mismo archivo deben agruparse juntos (#53)."""
@@ -489,7 +489,7 @@ class TestFormatJson:
         ]
         data = json.loads(format_json(results))
         assert "by_module" in data
-        assert len(data["by_module"]["modulo.py"]) == 2
+        assert len(data["by_module"]["src/modulo.py"]) == 2
 
     def test_format_json_by_module_archivos_distintos(self):
         """Archivos distintos del mismo directorio tienen entradas separadas (#53)."""
@@ -499,22 +499,22 @@ class TestFormatJson:
         ]
         data = json.loads(format_json(results))
         assert "by_module" in data
-        assert "a.py" in data["by_module"]
-        assert "b.py" in data["by_module"]
+        assert "src/a.py" in data["by_module"]
+        assert "src/b.py" in data["by_module"]
 
 
 class TestFormatResultsByModule:
     """Tests de agrupación por módulo en salida text (#53)."""
 
     def test_muestra_header_de_modulo(self, capsys):
-        """La salida text debe mostrar encabezado con nombre del módulo."""
+        """La salida text debe mostrar encabezado con directorio/módulo."""
         from quality_agents.codeguard.formatter import format_results as fmt
         results = [
             CheckResult("PEP8", Severity.ERROR, "msg", "mipaquete/modulo.py", 1),
         ]
         fmt(results, elapsed=0.1, total_files=1, checks_executed=3)
         out = capsys.readouterr().out
-        assert "modulo.py" in out
+        assert "mipaquete/modulo.py" in out
 
     def test_agrupa_dos_modulos(self, capsys):
         """Archivos distintos deben mostrar dos encabezados."""
@@ -525,5 +525,5 @@ class TestFormatResultsByModule:
         ]
         fmt(results, elapsed=0.1, total_files=2, checks_executed=3)
         out = capsys.readouterr().out
-        assert "x.py" in out
-        assert "y.py" in out
+        assert "paquete_a/x.py" in out
+        assert "paquete_b/y.py" in out

--- a/tests/unit/test_import_check.py
+++ b/tests/unit/test_import_check.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock, patch
 
 from quality_agents.codeguard.agent import Severity
 from quality_agents.codeguard.checks.import_check import ImportCheck
-from quality_agents.codeguard.config import CodeGuardConfig
+from quality_agents.codeguard.config import ChecksConfig, CodeGuardConfig
 from quality_agents.shared.verifiable import ExecutionContext
 
 
@@ -43,7 +43,7 @@ class TestImportCheckShouldRun:
         context = ExecutionContext(
             file_path=Path("test.py"),
             is_excluded=False,
-            config=CodeGuardConfig(check_imports=True),
+            config=CodeGuardConfig(checks=ChecksConfig(imports=True)),
         )
         assert check.should_run(context) is True
 
@@ -52,7 +52,7 @@ class TestImportCheckShouldRun:
         context = ExecutionContext(
             file_path=Path("test.py"),
             is_excluded=True,
-            config=CodeGuardConfig(check_imports=True),
+            config=CodeGuardConfig(checks=ChecksConfig(imports=True)),
         )
         assert check.should_run(context) is False
 
@@ -61,7 +61,7 @@ class TestImportCheckShouldRun:
         context = ExecutionContext(
             file_path=Path("test.txt"),
             is_excluded=False,
-            config=CodeGuardConfig(check_imports=True),
+            config=CodeGuardConfig(checks=ChecksConfig(imports=True)),
         )
         assert check.should_run(context) is False
 
@@ -70,7 +70,7 @@ class TestImportCheckShouldRun:
         context = ExecutionContext(
             file_path=Path("test.py"),
             is_excluded=False,
-            config=CodeGuardConfig(check_imports=False),
+            config=CodeGuardConfig(checks=ChecksConfig(imports=False)),
         )
         assert check.should_run(context) is False
 

--- a/tests/unit/test_pep8_check.py
+++ b/tests/unit/test_pep8_check.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock, patch
 
 from quality_agents.codeguard.agent import Severity
 from quality_agents.codeguard.checks.pep8_check import PEP8Check
-from quality_agents.codeguard.config import CodeGuardConfig
+from quality_agents.codeguard.config import ChecksConfig, CodeGuardConfig
 from quality_agents.shared.verifiable import ExecutionContext
 
 
@@ -43,7 +43,7 @@ class TestPEP8CheckShouldRun:
         context = ExecutionContext(
             file_path=Path("test.py"),
             is_excluded=False,
-            config=CodeGuardConfig(check_pep8=True),
+            config=CodeGuardConfig(checks=ChecksConfig(pep8=True)),
         )
         assert check.should_run(context) is True
 
@@ -52,7 +52,7 @@ class TestPEP8CheckShouldRun:
         context = ExecutionContext(
             file_path=Path("test.py"),
             is_excluded=True,
-            config=CodeGuardConfig(check_pep8=True),
+            config=CodeGuardConfig(checks=ChecksConfig(pep8=True)),
         )
         assert check.should_run(context) is False
 
@@ -61,7 +61,7 @@ class TestPEP8CheckShouldRun:
         context = ExecutionContext(
             file_path=Path("test.txt"),
             is_excluded=False,
-            config=CodeGuardConfig(check_pep8=True),
+            config=CodeGuardConfig(checks=ChecksConfig(pep8=True)),
         )
         assert check.should_run(context) is False
 
@@ -70,7 +70,7 @@ class TestPEP8CheckShouldRun:
         context = ExecutionContext(
             file_path=Path("test.py"),
             is_excluded=False,
-            config=CodeGuardConfig(check_pep8=False),
+            config=CodeGuardConfig(checks=ChecksConfig(pep8=False)),
         )
         assert check.should_run(context) is False
 

--- a/tests/unit/test_pylint_check.py
+++ b/tests/unit/test_pylint_check.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock, patch
 
 from quality_agents.codeguard.agent import Severity
 from quality_agents.codeguard.checks.pylint_check import PylintCheck
-from quality_agents.codeguard.config import CodeGuardConfig
+from quality_agents.codeguard.config import ChecksConfig, CodeGuardConfig
 from quality_agents.shared.verifiable import ExecutionContext
 
 
@@ -43,7 +43,7 @@ class TestPylintCheckShouldRun:
         context = ExecutionContext(
             file_path=Path("test.py"),
             is_excluded=False,
-            config=CodeGuardConfig(check_pylint=True),
+            config=CodeGuardConfig(checks=ChecksConfig(pylint=True)),
         )
         assert check.should_run(context) is True
 
@@ -52,7 +52,7 @@ class TestPylintCheckShouldRun:
         context = ExecutionContext(
             file_path=Path("test.py"),
             is_excluded=True,
-            config=CodeGuardConfig(check_pylint=True),
+            config=CodeGuardConfig(checks=ChecksConfig(pylint=True)),
         )
         assert check.should_run(context) is False
 
@@ -61,7 +61,7 @@ class TestPylintCheckShouldRun:
         context = ExecutionContext(
             file_path=Path("test.txt"),
             is_excluded=False,
-            config=CodeGuardConfig(check_pylint=True),
+            config=CodeGuardConfig(checks=ChecksConfig(pylint=True)),
         )
         assert check.should_run(context) is False
 
@@ -70,7 +70,7 @@ class TestPylintCheckShouldRun:
         context = ExecutionContext(
             file_path=Path("test.py"),
             is_excluded=False,
-            config=CodeGuardConfig(check_pylint=False),
+            config=CodeGuardConfig(checks=ChecksConfig(pylint=False)),
         )
         assert check.should_run(context) is False
 

--- a/tests/unit/test_security_check.py
+++ b/tests/unit/test_security_check.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock, patch
 
 from quality_agents.codeguard.agent import Severity
 from quality_agents.codeguard.checks.security_check import SecurityCheck
-from quality_agents.codeguard.config import CodeGuardConfig
+from quality_agents.codeguard.config import ChecksConfig, CodeGuardConfig
 from quality_agents.shared.verifiable import ExecutionContext
 
 
@@ -44,7 +44,7 @@ class TestSecurityCheckShouldRun:
         context = ExecutionContext(
             file_path=Path("test.py"),
             is_excluded=False,
-            config=CodeGuardConfig(check_security=True),
+            config=CodeGuardConfig(checks=ChecksConfig(security=True)),
         )
         assert check.should_run(context) is True
 
@@ -53,7 +53,7 @@ class TestSecurityCheckShouldRun:
         context = ExecutionContext(
             file_path=Path("test.py"),
             is_excluded=True,
-            config=CodeGuardConfig(check_security=True),
+            config=CodeGuardConfig(checks=ChecksConfig(security=True)),
         )
         assert check.should_run(context) is False
 
@@ -62,7 +62,7 @@ class TestSecurityCheckShouldRun:
         context = ExecutionContext(
             file_path=Path("test.txt"),
             is_excluded=False,
-            config=CodeGuardConfig(check_security=True),
+            config=CodeGuardConfig(checks=ChecksConfig(security=True)),
         )
         assert check.should_run(context) is False
 
@@ -71,7 +71,7 @@ class TestSecurityCheckShouldRun:
         context = ExecutionContext(
             file_path=Path("test.py"),
             is_excluded=False,
-            config=CodeGuardConfig(check_security=False),
+            config=CodeGuardConfig(checks=ChecksConfig(security=False)),
         )
         assert check.should_run(context) is False
 

--- a/tests/unit/test_type_check.py
+++ b/tests/unit/test_type_check.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock, patch
 
 from quality_agents.codeguard.agent import Severity
 from quality_agents.codeguard.checks.type_check import TypeCheck
-from quality_agents.codeguard.config import CodeGuardConfig
+from quality_agents.codeguard.config import ChecksConfig, CodeGuardConfig
 from quality_agents.shared.verifiable import ExecutionContext
 
 
@@ -44,7 +44,7 @@ class TestTypeCheckShouldRun:
         context = ExecutionContext(
             file_path=Path("test.py"),
             is_excluded=False,
-            config=CodeGuardConfig(check_types=True),
+            config=CodeGuardConfig(checks=ChecksConfig(types=True)),
         )
         assert check.should_run(context) is True
 
@@ -54,7 +54,7 @@ class TestTypeCheckShouldRun:
         context = ExecutionContext(
             file_path=Path("test.py"),
             is_excluded=False,
-            config=CodeGuardConfig(check_types=True),
+            config=CodeGuardConfig(checks=ChecksConfig(types=True)),
         )
         assert check.should_run(context) is False
 
@@ -64,7 +64,7 @@ class TestTypeCheckShouldRun:
         context = ExecutionContext(
             file_path=Path("test.py"),
             is_excluded=True,
-            config=CodeGuardConfig(check_types=True),
+            config=CodeGuardConfig(checks=ChecksConfig(types=True)),
         )
         assert check.should_run(context) is False
 
@@ -73,7 +73,7 @@ class TestTypeCheckShouldRun:
         context = ExecutionContext(
             file_path=Path("test.txt"),
             is_excluded=False,
-            config=CodeGuardConfig(check_types=True),
+            config=CodeGuardConfig(checks=ChecksConfig(types=True)),
         )
         assert check.should_run(context) is False
 
@@ -83,7 +83,7 @@ class TestTypeCheckShouldRun:
         context = ExecutionContext(
             file_path=Path("test.py"),
             is_excluded=False,
-            config=CodeGuardConfig(check_types=False),
+            config=CodeGuardConfig(checks=ChecksConfig(types=False)),
         )
         assert check.should_run(context) is False
 


### PR DESCRIPTION
## Resumen

Incremento 1 del plan v0.4.0: mejoras de UX en el output y sistema de toggles por check/analyzer/métrica para los tres agentes.

### Cambios incluidos

- **#53 / #56 — Output agrupado por módulo** (`directorio/archivo.py` en lugar de paquete): elimina colisiones de `__init__.py` y mejora la navegabilidad del output. JSON: `by_package` → `by_module`.
- **#60 — CodeGuard toggles** vía `[tool.codeguard.checks]`: los campos `check_pep8`, `check_security`, etc. se movieron a la subsección `checks`.
- **#61 — DesignReviewer toggles** vía `[tool.designreviewer.checks]`: 12 analyzers configurables individualmente.
- **#62 — ArchitectAnalyst toggles** vía `[tool.architectanalyst.checks]`: 6 métricas configurables individualmente.
- Fix de dos tests de integración que apuntaban a ruta incorrecta del ejemplo pre-commit.

### Nota de migración (breaking change menor)

Los campos `check_pep8`, `check_pylint`, `check_security`, `check_complexity`, `check_types`, `check_imports` en `[tool.codeguard]` ya no son válidos. Moverlos a `[tool.codeguard.checks]` sin el prefijo `check_`.

## Test plan

- [ ] `pytest tests/unit/test_codeguard_config.py` — verifica `ChecksConfig` y `from_pyproject_toml`
- [ ] `pytest tests/unit/test_designreviewer_config.py` — verifica `DesignReviewerChecksConfig`
- [ ] `pytest tests/unit/test_architectanalyst_config.py` — verifica `ArchitectAnalystChecksConfig`
- [ ] `pytest tests/unit/test_formatter.py` — verifica `by_module` en JSON
- [ ] `pytest tests/unit/test_designreviewer_formatter.py` — verifica `by_module` en JSON
- [ ] `pytest tests/integration/test_pre_commit_hooks.py` — verifica rutas de ejemplo (fixes previos)
- [ ] `pytest` (suite completa) — sin regresiones

🤖 Generated with [Claude Code](https://claude.com/claude-code)