### PR TITLE
Incremento 4: mejoras ArchitectAnalyst (#47 #48 #49 #57 #58)

### DIFF
--- a/src/quality_agents/architectanalyst/config.py
+++ b/src/quality_agents/architectanalyst/config.py
@@ -130,6 +130,12 @@ class ArchitectAnalystConfig:
         "build",
     ])
 
+    # --- Roles de capa para calibración arquitectural (CQRS/ES/Hexagonal) ---
+    # Mapeo glob → "leaf" | "stable"
+    # leaf:   módulo terminal — se advierte si I es bajo (algo depende de él)
+    # stable: módulo estable — se advierte si I es alto (comportamiento actual)
+    layer_roles: Dict[str, str] = field(default_factory=dict)
+
     # --- Subsecciones ---
     checks: ArchitectAnalystChecksConfig = field(default_factory=ArchitectAnalystChecksConfig)
     ai: AIConfig = field(default_factory=AIConfig)
@@ -174,6 +180,7 @@ class ArchitectAnalystConfig:
         ai_data = tool_config.pop("ai", {})
         layers_data = tool_config.pop("layers", {})
         checks_data = tool_config.pop("checks", {})
+        layer_roles_data = tool_config.pop("layer_roles", {})
 
         ai_config = AIConfig(**_filter_fields(AIConfig, ai_data)) if ai_data else AIConfig()
         layers_config = LayersConfig(rules=layers_data) if layers_data else LayersConfig()
@@ -186,6 +193,7 @@ class ArchitectAnalystConfig:
         config.ai = ai_config
         config.layers = layers_config
         config.checks = checks_config
+        config.layer_roles = layer_roles_data
         return config
 
 

--- a/src/quality_agents/architectanalyst/config.py
+++ b/src/quality_agents/architectanalyst/config.py
@@ -62,6 +62,7 @@ class ArchitectAnalystChecksConfig:
     dependency_cycles: bool = True
     layer_violations: bool = True
     relational_cohesion: bool = True
+    god_package: bool = True
 
 
 @dataclass
@@ -133,6 +134,10 @@ class ArchitectAnalystConfig:
 
     # --- Cohesión Relacional ---
     min_relational_cohesion: float = 1.5   # H < umbral → WARNING
+
+    # --- God Package ---
+    max_package_classes: int = 20          # n_clases > umbral → WARNING
+    max_package_ca: int = 10               # Ca > umbral → WARNING
 
     # --- Profundidad de análisis para DistanceAnalyzer ---
     # 1 = primer componente del módulo (default, comportamiento original)

--- a/src/quality_agents/architectanalyst/config.py
+++ b/src/quality_agents/architectanalyst/config.py
@@ -61,6 +61,7 @@ class ArchitectAnalystChecksConfig:
     distance: bool = True
     dependency_cycles: bool = True
     layer_violations: bool = True
+    relational_cohesion: bool = True
 
 
 @dataclass
@@ -129,6 +130,9 @@ class ArchitectAnalystConfig:
         "dist",
         "build",
     ])
+
+    # --- Cohesión Relacional ---
+    min_relational_cohesion: float = 1.5   # H < umbral → WARNING
 
     # --- Profundidad de análisis para DistanceAnalyzer ---
     # 1 = primer componente del módulo (default, comportamiento original)

--- a/src/quality_agents/architectanalyst/config.py
+++ b/src/quality_agents/architectanalyst/config.py
@@ -63,6 +63,7 @@ class ArchitectAnalystChecksConfig:
     layer_violations: bool = True
     relational_cohesion: bool = True
     god_package: bool = True
+    coverage: bool = True
 
 
 @dataclass
@@ -138,6 +139,10 @@ class ArchitectAnalystConfig:
     # --- God Package ---
     max_package_classes: int = 20          # n_clases > umbral → WARNING
     max_package_ca: int = 10               # Ca > umbral → WARNING
+
+    # --- Cobertura de tests ---
+    min_coverage: float = 80.0             # cobertura < umbral → WARNING
+    coverage_report_path: str = "coverage.json"  # relativo al project_path
 
     # --- Profundidad de análisis para DistanceAnalyzer ---
     # 1 = primer componente del módulo (default, comportamiento original)

--- a/src/quality_agents/architectanalyst/config.py
+++ b/src/quality_agents/architectanalyst/config.py
@@ -130,6 +130,11 @@ class ArchitectAnalystConfig:
         "build",
     ])
 
+    # --- Profundidad de análisis para DistanceAnalyzer ---
+    # 1 = primer componente del módulo (default, comportamiento original)
+    # 2 = dos componentes — útil en arquitecturas hexagonales con namespace de app
+    analysis_depth: int = 1
+
     # --- Roles de capa para calibración arquitectural (CQRS/ES/Hexagonal) ---
     # Mapeo glob → "leaf" | "stable"
     # leaf:   módulo terminal — se advierte si I es bajo (algo depende de él)

--- a/src/quality_agents/architectanalyst/metrics/__init__.py
+++ b/src/quality_agents/architectanalyst/metrics/__init__.py
@@ -10,6 +10,7 @@ from quality_agents.architectanalyst.metrics.dependency_cycles_analyzer import (
     DependencyCyclesAnalyzer,
 )
 from quality_agents.architectanalyst.metrics.distance_analyzer import DistanceAnalyzer
+from quality_agents.architectanalyst.metrics.god_package_analyzer import GodPackageAnalyzer
 from quality_agents.architectanalyst.metrics.instability_analyzer import InstabilityAnalyzer
 from quality_agents.architectanalyst.metrics.layer_violations_analyzer import (
     LayerViolationsAnalyzer,
@@ -26,4 +27,5 @@ __all__ = [
     "AbstractnessAnalyzer",
     "DistanceAnalyzer",
     "RelationalCohesionAnalyzer",
+    "GodPackageAnalyzer",
 ]

--- a/src/quality_agents/architectanalyst/metrics/__init__.py
+++ b/src/quality_agents/architectanalyst/metrics/__init__.py
@@ -14,6 +14,9 @@ from quality_agents.architectanalyst.metrics.instability_analyzer import Instabi
 from quality_agents.architectanalyst.metrics.layer_violations_analyzer import (
     LayerViolationsAnalyzer,
 )
+from quality_agents.architectanalyst.metrics.relational_cohesion_analyzer import (
+    RelationalCohesionAnalyzer,
+)
 
 __all__ = [
     "DependencyCyclesAnalyzer",
@@ -22,4 +25,5 @@ __all__ = [
     "InstabilityAnalyzer",
     "AbstractnessAnalyzer",
     "DistanceAnalyzer",
+    "RelationalCohesionAnalyzer",
 ]

--- a/src/quality_agents/architectanalyst/metrics/__init__.py
+++ b/src/quality_agents/architectanalyst/metrics/__init__.py
@@ -6,6 +6,7 @@ Cada métrica hereda de ProjectMetric y se auto-descubre via MetricOrchestrator.
 
 from quality_agents.architectanalyst.metrics.abstractness_analyzer import AbstractnessAnalyzer
 from quality_agents.architectanalyst.metrics.coupling_analyzer import CouplingAnalyzer
+from quality_agents.architectanalyst.metrics.coverage_analyzer import CoverageAnalyzer
 from quality_agents.architectanalyst.metrics.dependency_cycles_analyzer import (
     DependencyCyclesAnalyzer,
 )
@@ -28,4 +29,5 @@ __all__ = [
     "DistanceAnalyzer",
     "RelationalCohesionAnalyzer",
     "GodPackageAnalyzer",
+    "CoverageAnalyzer",
 ]

--- a/src/quality_agents/architectanalyst/metrics/coverage_analyzer.py
+++ b/src/quality_agents/architectanalyst/metrics/coverage_analyzer.py
@@ -1,0 +1,118 @@
+"""
+CoverageAnalyzer — Cobertura de tests en el reporte de ArchitectAnalyst.
+
+Lee el archivo coverage.json generado por `pytest --cov --cov-report=json`
+y reporta el porcentaje de líneas cubiertas.
+
+Comportamiento:
+  - Archivo no encontrado  → WARNING (sin datos de cobertura)
+  - Archivo inválido       → WARNING (no se pudo leer)
+  - Cobertura < umbral     → WARNING
+  - Cobertura >= umbral    → INFO
+
+Umbrales en ArchitectAnalystConfig:
+  coverage_report_path (default: "coverage.json") → ruta relativa al project_path
+  min_coverage         (default: 80.0)            → porcentaje mínimo esperado
+
+Ticket: Issue #49
+Fecha: 2026-05-27
+"""
+
+import json
+from pathlib import Path
+from typing import Any, List
+
+from quality_agents.architectanalyst.models import ArchitectureResult, ArchitectureSeverity
+from quality_agents.architectanalyst.orchestrator import ProjectMetric
+
+
+class CoverageAnalyzer(ProjectMetric):
+    """
+    Reporta la cobertura de tests leyendo coverage.json.
+
+    WARNING si no se encuentra el archivo o si cobertura < min_coverage.
+    INFO si la cobertura supera el umbral.
+    """
+
+    def __init__(self) -> None:
+        self._config: Any = None
+
+    @property
+    def name(self) -> str:
+        return "CoverageAnalyzer"
+
+    @property
+    def category(self) -> str:
+        return "quality"
+
+    @property
+    def estimated_duration(self) -> float:
+        return 1.0
+
+    @property
+    def priority(self) -> int:
+        return 11
+
+    def should_run(self, config: Any) -> bool:
+        self._config = config
+        if config and hasattr(config, "checks"):
+            if not getattr(config.checks, "coverage", True):
+                return False
+        return True
+
+    def analyze(self, project_path: Path, files: List[Path]) -> List[ArchitectureResult]:
+        config = self._config
+        min_cov = getattr(config, "min_coverage", 80.0) if config else 80.0
+        report_path_str = (
+            getattr(config, "coverage_report_path", "coverage.json") if config else "coverage.json"
+        )
+
+        report_path = project_path / report_path_str
+
+        if not report_path.exists():
+            return [ArchitectureResult(
+                analyzer_name=self.name,
+                metric_name="coverage",
+                module_path=Path("."),
+                value=0.0,
+                threshold=min_cov,
+                severity=ArchitectureSeverity.WARNING,
+                message=(
+                    f"No se encontró el archivo de cobertura '{report_path_str}'. "
+                    f"Generalo con: pytest --cov --cov-report=json"
+                ),
+            )]
+
+        try:
+            data = json.loads(report_path.read_text(encoding="utf-8"))
+            percent = float(data["totals"]["percent_covered"])
+        except (json.JSONDecodeError, KeyError, OSError, TypeError, ValueError):
+            return [ArchitectureResult(
+                analyzer_name=self.name,
+                metric_name="coverage",
+                module_path=Path("."),
+                value=0.0,
+                threshold=min_cov,
+                severity=ArchitectureSeverity.WARNING,
+                message=(
+                    f"No se pudo leer el archivo de cobertura '{report_path_str}'. "
+                    f"Verificá que sea un JSON válido generado por coverage.py."
+                ),
+            )]
+
+        severity = (
+            ArchitectureSeverity.WARNING if percent < min_cov else ArchitectureSeverity.INFO
+        )
+        comparison = "por debajo del" if percent < min_cov else "dentro del"
+        return [ArchitectureResult(
+            analyzer_name=self.name,
+            metric_name="coverage",
+            module_path=Path("."),
+            value=round(percent, 1),
+            threshold=min_cov,
+            severity=severity,
+            message=(
+                f"Cobertura de tests: {percent:.1f}% "
+                f"({comparison} umbral mínimo de {min_cov}%)."
+            ),
+        )]

--- a/src/quality_agents/architectanalyst/metrics/distance_analyzer.py
+++ b/src/quality_agents/architectanalyst/metrics/distance_analyzer.py
@@ -6,16 +6,15 @@ D (Distance from Main Sequence) = |A + I - 1|
 La Main Sequence es la línea ideal A + I = 1. Paquetes sobre esa línea
 tienen el balance perfecto entre estabilidad y abstracción.
 
-Las métricas se calculan a nivel de **paquete** (directorio de primer nivel),
-no de módulo individual. Esto sigue la definición original de Robert C. Martin
-y evita falsos positivos: cualquier clase concreta tiene A=0, I=0 → D=1.00
-si se analiza por módulo.
+Las métricas se calculan a nivel de **paquete**, cuya granularidad se controla
+con `analysis_depth` (default: 1 = primer componente del módulo).
+
+Con depth=1: `myapp.domain.model` → paquete `myapp`
+Con depth=2: `myapp.domain.model` → paquete `myapp.domain`
 
 Zonas problemáticas:
-  Zone of Pain (A≈0, I≈0): paquete estable pero concreto — muy rígido,
-    difícil de cambiar porque muchos dependen de una implementación concreta.
-  Zone of Uselessness (A≈1, I≈1): paquete abstracto pero inestable —
-    nadie depende de él, las abstracciones no se usan.
+  Zone of Pain (A≈0, I≈0): paquete estable pero concreto — muy rígido.
+  Zone of Uselessness (A≈1, I≈1): paquete abstracto pero nadie depende de él.
 
 Rango de D: [0.0, 1.0]
   0.0 = sobre la Main Sequence (ideal)
@@ -25,8 +24,8 @@ Umbrales en ArchitectAnalystConfig:
   max_distance_warning  (default: 0.3) → WARNING
   max_distance_critical (default: 0.5) → CRITICAL
 
-Ticket: 2.5 / Issue #33
-Fecha: 2026-03-01 / 2026-03-08
+Ticket: 2.5 / Issues #33 #48
+Fecha: 2026-03-01 / 2026-05-27
 """
 
 import ast
@@ -102,6 +101,7 @@ class DistanceAnalyzer(ProjectMetric):
         config = self._config
         warn_threshold = config.max_distance_warning if config is not None else 0.3
         crit_threshold = config.max_distance_critical if config is not None else 0.5
+        depth = getattr(config, "analysis_depth", 1) if config is not None else 1
 
         builder = DependencyGraphBuilder()
         graph = builder.build(project_path, files)
@@ -109,7 +109,7 @@ class DistanceAnalyzer(ProjectMetric):
         python_files = [f for f in files if f.suffix == ".py"]
         module_to_file = self._build_module_to_file(project_path, python_files, graph.modules)
 
-        package_data = self._aggregate_to_packages(graph, module_to_file)
+        package_data = self._aggregate_to_packages(graph, module_to_file, depth)
 
         results: List[ArchitectureResult] = []
 
@@ -162,12 +162,14 @@ class DistanceAnalyzer(ProjectMetric):
         self,
         graph: Any,
         module_to_file: Dict[str, Path],
+        depth: int = 1,
     ) -> Dict[str, Dict[str, Any]]:
         """
         Agrega métricas de módulos individuales al nivel de paquete.
 
-        Un paquete es el primer componente del nombre dotted del módulo.
-        Por ejemplo: `entidades.sensor` → paquete `entidades`.
+        La granularidad del paquete se controla con `depth`:
+          depth=1: `myapp.domain.model` → `myapp`   (default, comportamiento original)
+          depth=2: `myapp.domain.model` → `myapp.domain`
 
         Ca y Ce se calculan contando dependencias **entre paquetes distintos**,
         no entre módulos individuales.
@@ -175,6 +177,7 @@ class DistanceAnalyzer(ProjectMetric):
         Args:
             graph: DependencyGraph con módulos y sus dependencias.
             module_to_file: Mapa módulo → archivo para parsear clases.
+            depth: Número de componentes del módulo que forman el nombre del paquete.
 
         Returns:
             Diccionario paquete → {abstract_classes, total_classes, ca, ce}.
@@ -185,7 +188,7 @@ class DistanceAnalyzer(ProjectMetric):
         pkg_modules: Dict[str, Set[str]] = defaultdict(set)
 
         for module in graph.modules:
-            pkg = module.split(".")[0]
+            pkg = ".".join(module.split(".")[:depth])
             pkg_modules[pkg].add(module)
 
             file_path = module_to_file.get(module)
@@ -202,7 +205,7 @@ class DistanceAnalyzer(ProjectMetric):
             ce_pkgs: Set[str] = set()
             for m in pkg_modules[pkg]:
                 for dep in graph.efferent_coupling(m):
-                    dep_pkg = dep.split(".")[0]
+                    dep_pkg = ".".join(dep.split(".")[:depth])
                     if dep_pkg != pkg and dep_pkg in all_packages:
                         ce_pkgs.add(dep_pkg)
 
@@ -213,7 +216,7 @@ class DistanceAnalyzer(ProjectMetric):
                     continue
                 for m in pkg_modules[other_pkg]:
                     for dep in graph.efferent_coupling(m):
-                        if dep.split(".")[0] == pkg:
+                        if ".".join(dep.split(".")[:depth]) == pkg:
                             ca_pkgs.add(other_pkg)
                             break
 

--- a/src/quality_agents/architectanalyst/metrics/god_package_analyzer.py
+++ b/src/quality_agents/architectanalyst/metrics/god_package_analyzer.py
@@ -1,0 +1,182 @@
+"""
+GodPackageAnalyzer — Detecta paquetes con demasiada concentración.
+
+Un God Package concentra demasiado en una de dos formas:
+  1. Demasiadas clases  → responsabilidades mezcladas
+  2. Ca muy alto        → casi todo el sistema depende de él
+
+Umbrales en ArchitectAnalystConfig:
+  max_package_classes (default: 20) → WARNING si n_clases > umbral
+  max_package_ca      (default: 10) → WARNING si Ca > umbral
+
+La granularidad del paquete se controla con `analysis_depth` (default: 1),
+igual que DistanceAnalyzer y RelationalCohesionAnalyzer.
+
+Ticket: Issue #58
+Fecha: 2026-05-27
+"""
+
+import ast
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Dict, List, Set
+
+from quality_agents.architectanalyst.metrics.dependency_graph import DependencyGraphBuilder
+from quality_agents.architectanalyst.models import ArchitectureResult, ArchitectureSeverity
+from quality_agents.architectanalyst.orchestrator import ProjectMetric
+
+
+class GodPackageAnalyzer(ProjectMetric):
+    """
+    Detecta paquetes con exceso de clases o acoplamiento aferente (Ca) excesivo.
+
+    WARNING si n_clases > max_package_classes (demasiadas responsabilidades).
+    WARNING si Ca > max_package_ca (demasiados dependientes — núcleo frágil).
+    """
+
+    def __init__(self) -> None:
+        self._config: Any = None
+
+    @property
+    def name(self) -> str:
+        return "GodPackageAnalyzer"
+
+    @property
+    def category(self) -> str:
+        return "smells"
+
+    @property
+    def estimated_duration(self) -> float:
+        return 3.0
+
+    @property
+    def priority(self) -> int:
+        return 10
+
+    def should_run(self, config: Any) -> bool:
+        self._config = config
+        if config and hasattr(config, "checks"):
+            if not getattr(config.checks, "god_package", True):
+                return False
+        return True
+
+    def analyze(self, project_path: Path, files: List[Path]) -> List[ArchitectureResult]:
+        config = self._config
+        max_classes = getattr(config, "max_package_classes", 20) if config else 20
+        max_ca = getattr(config, "max_package_ca", 10) if config else 10
+        depth = getattr(config, "analysis_depth", 1) if config else 1
+
+        builder = DependencyGraphBuilder()
+        graph = builder.build(project_path, files)
+
+        python_files = [f for f in files if f.suffix == ".py"]
+        module_to_file = self._build_module_to_file(project_path, python_files, graph.modules)
+
+        package_data = self._compute_package_data(graph, module_to_file, depth)
+
+        results: List[ArchitectureResult] = []
+
+        for pkg in sorted(package_data.keys()):
+            n_classes = package_data[pkg]["n_classes"]
+            ca = package_data[pkg]["ca"]
+
+            if n_classes > max_classes:
+                results.append(ArchitectureResult(
+                    analyzer_name=self.name,
+                    metric_name="GodPackage.Classes",
+                    module_path=Path(pkg.replace(".", "/")),
+                    value=float(n_classes),
+                    threshold=float(max_classes),
+                    severity=ArchitectureSeverity.WARNING,
+                    message=(
+                        f"God Package por tamaño: '{pkg}' tiene {n_classes} clases "
+                        f"(umbral: {max_classes}). "
+                        f"Demasiadas responsabilidades concentradas en un paquete."
+                    ),
+                ))
+
+            if ca > max_ca:
+                results.append(ArchitectureResult(
+                    analyzer_name=self.name,
+                    metric_name="GodPackage.Ca",
+                    module_path=Path(pkg.replace(".", "/")),
+                    value=float(ca),
+                    threshold=float(max_ca),
+                    severity=ArchitectureSeverity.WARNING,
+                    message=(
+                        f"God Package por acoplamiento: '{pkg}' tiene Ca={ca} "
+                        f"(umbral: {max_ca}). "
+                        f"Demasiados paquetes dependen de este paquete."
+                    ),
+                ))
+
+        return results
+
+    def _compute_package_data(
+        self,
+        graph: Any,
+        module_to_file: Dict[str, Path],
+        depth: int,
+    ) -> Dict[str, Dict[str, int]]:
+        """
+        Calcula n_classes (total de clases) y ca (acoplamiento aferente) por paquete.
+
+        Ca cuenta paquetes distintos que tienen al menos un módulo que importa
+        algún módulo de este paquete.
+        """
+        pkg_modules: Dict[str, Set[str]] = defaultdict(set)
+
+        for module in graph.modules:
+            pkg = ".".join(module.split(".")[:depth])
+            pkg_modules[pkg].add(module)
+
+        all_packages = set(pkg_modules.keys())
+        result: Dict[str, Dict[str, int]] = {}
+
+        for pkg, modules in pkg_modules.items():
+            # n_classes: total de clases en todos los módulos del paquete
+            n_classes = 0
+            for m in modules:
+                file_path = module_to_file.get(m)
+                if file_path:
+                    n_classes += self._count_classes(file_path)
+
+            # ca: paquetes distintos que dependen de este paquete
+            ca_pkgs: Set[str] = set()
+            for other_pkg in all_packages:
+                if other_pkg == pkg:
+                    continue
+                for m in pkg_modules[other_pkg]:
+                    for dep in graph.efferent_coupling(m):
+                        dep_pkg = ".".join(dep.split(".")[:depth])
+                        if dep_pkg == pkg:
+                            ca_pkgs.add(other_pkg)
+                            break
+
+            result[pkg] = {"n_classes": n_classes, "ca": len(ca_pkgs)}
+
+        return result
+
+    def _count_classes(self, file_path: Path) -> int:
+        """Cuenta el número de clases definidas en el archivo."""
+        try:
+            source = file_path.read_text(encoding="utf-8")
+            tree = ast.parse(source, filename=str(file_path))
+        except (OSError, SyntaxError):
+            return 0
+        return sum(1 for node in ast.walk(tree) if isinstance(node, ast.ClassDef))
+
+    def _build_module_to_file(
+        self,
+        project_path: Path,
+        files: List[Path],
+        known_modules: Set[str],
+    ) -> Dict[str, Path]:
+        """Construye mapa módulo → Path de archivo."""
+        builder = DependencyGraphBuilder()
+        result: Dict[str, Path] = {}
+        for f in files:
+            name = builder._path_to_module(f, project_path)
+            if name and name in known_modules:
+                result[name] = f
+        return result

--- a/src/quality_agents/architectanalyst/metrics/instability_analyzer.py
+++ b/src/quality_agents/architectanalyst/metrics/instability_analyzer.py
@@ -7,38 +7,43 @@ Rango: [0.0, 1.0]
   0.0 = totalmente estable — muchos dependen de él, él no depende de nadie
   1.0 = totalmente inestable — nadie depende de él, él depende de muchos
 
-Un módulo con I alto es frágil porque cambios en sus dependencias lo afectan
-sin que otros módulos absorban el impacto. Idealmente los módulos estables
-(I bajo) son abstracciones (A alto), y los inestables son implementaciones (A bajo).
+Con layer_roles, los módulos pueden tener roles explícitos que ajustan la lógica:
+  stable: se advierte si I > max_instability (comportamiento default)
+  leaf:   módulo terminal — se advierte si I < (1 - max_instability),
+          porque algo depende de él cuando no debería.
 
-Umbral: max_instability en ArchitectAnalystConfig (default: 0.8).
-Severidad: WARNING si I > max_instability.
-
-Ticket: 2.3
-Fecha: 2026-03-01
+Ticket: 2.3 / Issue #47
+Fecha: 2026-03-01 / 2026-05-27
 """
 
+import fnmatch
 from pathlib import Path
-from typing import Any, List
+from typing import Any, Dict, List, Optional
 
 from quality_agents.architectanalyst.metrics._utils import calculate_instability
 from quality_agents.architectanalyst.metrics.dependency_graph import DependencyGraphBuilder
 from quality_agents.architectanalyst.models import ArchitectureResult, ArchitectureSeverity
 from quality_agents.architectanalyst.orchestrator import ProjectMetric
 
+_VALID_ROLES = {"leaf", "stable"}
+
 
 class InstabilityAnalyzer(ProjectMetric):
     """
-    Detecta módulos con inestabilidad excesiva (I > max_instability).
+    Detecta módulos con inestabilidad excesiva o inadecuada según su rol arquitectural.
 
-    I = Ce / (Ca + Ce)
+    Comportamiento por defecto (sin layer_roles):
+        WARNING si I > max_instability
 
-    Solo genera resultados cuando I supera el umbral configurado (WARNING).
-    Los módulos aislados (Ca=0, Ce=0) tienen I=0.0 por definición y se omiten.
+    Con layer_roles configurado:
+        stable → WARNING si I > max_instability (igual que default)
+        leaf   → WARNING si I < (1 - max_instability): algo depende de un módulo terminal
 
     Umbral por defecto: 0.8 (configurable vía max_instability en pyproject.toml).
-    Severidad: WARNING.
     """
+
+    def __init__(self) -> None:
+        self._config: Any = None
 
     @property
     def name(self) -> str:
@@ -56,19 +61,16 @@ class InstabilityAnalyzer(ProjectMetric):
     def priority(self) -> int:
         return 6
 
+    def should_run(self, config: Any) -> bool:
+        self._config = config
+        if config and hasattr(config, "checks") and not config.checks.instability:
+            return False
+        return True
+
     def analyze(self, project_path: Path, files: List[Path]) -> List[ArchitectureResult]:
-        """
-        Analiza el proyecto y reporta módulos con inestabilidad excesiva.
-
-        Args:
-            project_path: Directorio raíz del proyecto.
-            files: Lista de archivos Python a analizar.
-
-        Returns:
-            Lista de ArchitectureResult WARNING para módulos con I > max_instability.
-        """
         config = self._config
         threshold = config.max_instability if config is not None else 0.8
+        layer_roles: Dict[str, str] = getattr(config, "layer_roles", {}) if config else {}
 
         builder = DependencyGraphBuilder()
         graph = builder.build(project_path, files)
@@ -79,34 +81,77 @@ class InstabilityAnalyzer(ProjectMetric):
             ca = len(graph.afferent_coupling(module))
             ce = len(graph.efferent_coupling(module))
 
-            # Módulos aislados: I=0.0 por convención (no violan nada)
             if ca == 0 and ce == 0:
                 continue
 
             instability = calculate_instability(ca, ce)
+            role = self._resolve_role(module, layer_roles)
 
-            if instability > threshold:
-                results.append(ArchitectureResult(
-                    analyzer_name=self.name,
-                    metric_name="I",
-                    module_path=Path(module.replace(".", "/")),
-                    value=round(instability, 3),
-                    threshold=threshold,
-                    severity=ArchitectureSeverity.WARNING,
-                    message=(
-                        f"Inestabilidad I={instability:.2f} > {threshold} "
-                        f"(Ca={ca}, Ce={ce}). Módulo depende de muchos otros "
-                        f"sin que nadie estabilice sus dependencias."
-                    ),
-                ))
+            result = self._evaluar_modulo(module, instability, ca, ce, threshold, role)
+            if result:
+                results.append(result)
 
         return results
 
-    def __init__(self) -> None:
-        self._config: Any = None
+    def _resolve_role(self, module: str, layer_roles: Dict[str, str]) -> Optional[str]:
+        """
+        Retorna el rol del módulo según layer_roles, o None si no hay match.
 
-    def should_run(self, config: Any) -> bool:
-        self._config = config
-        if config and hasattr(config, "checks") and not config.checks.instability:
-            return False
-        return True
+        El módulo se convierte a formato de path (puntos → barras) para
+        que los patrones glob funcionen naturalmente (*/application/commands/*).
+        """
+        module_path = module.replace(".", "/")
+        for pattern, role in layer_roles.items():
+            if role in _VALID_ROLES and fnmatch.fnmatch(module_path, pattern):
+                return role
+        return None
+
+    def _evaluar_modulo(
+        self,
+        module: str,
+        instability: float,
+        ca: int,
+        ce: int,
+        threshold: float,
+        role: Optional[str],
+    ) -> Optional[ArchitectureResult]:
+        """Evalúa un módulo y retorna un resultado si hay violación, o None."""
+        module_path = Path(module.replace(".", "/"))
+
+        if role == "leaf":
+            # Un leaf debería ser inestable (nadie depende de él).
+            # Si I es bajo significa que algo depende de él — inesperado.
+            leaf_threshold = 1.0 - threshold
+            if instability < leaf_threshold:
+                return ArchitectureResult(
+                    analyzer_name=self.name,
+                    metric_name="I",
+                    module_path=module_path,
+                    value=round(instability, 3),
+                    threshold=leaf_threshold,
+                    severity=ArchitectureSeverity.WARNING,
+                    message=(
+                        f"Leaf module '{module}' tiene I={instability:.2f} < {leaf_threshold:.2f}. "
+                        f"Un módulo terminal no debería tener dependientes (Ca={ca}). "
+                        f"Verificar si la arquitectura CQRS/ES está bien estructurada."
+                    ),
+                )
+            return None
+
+        # Rol "stable" o sin rol: comportamiento por defecto
+        if instability > threshold:
+            role_info = f" [rol: {role}]" if role else ""
+            return ArchitectureResult(
+                analyzer_name=self.name,
+                metric_name="I",
+                module_path=module_path,
+                value=round(instability, 3),
+                threshold=threshold,
+                severity=ArchitectureSeverity.WARNING,
+                message=(
+                    f"Inestabilidad I={instability:.2f} > {threshold}{role_info} "
+                    f"(Ca={ca}, Ce={ce}). Módulo depende de muchos otros "
+                    f"sin que nadie estabilice sus dependencias."
+                ),
+            )
+        return None

--- a/src/quality_agents/architectanalyst/metrics/relational_cohesion_analyzer.py
+++ b/src/quality_agents/architectanalyst/metrics/relational_cohesion_analyzer.py
@@ -1,0 +1,174 @@
+"""
+RelationalCohesionAnalyzer — Cohesión Relacional (H) por paquete.
+
+H (Relational Cohesion) = (R + 1) / N
+
+  R = relaciones internas del paquete (imports entre módulos del mismo paquete)
+  N = número de tipos (clases) en el paquete
+
+Rango esperado: 1.5 – 4.0 (según Robert C. Martin)
+  H < 1.0 → paquete casi sin cohesión interna
+  H ≈ 1.0 → una relación por tipo (mínimo)
+  H >> 4.0 → posible over-coupling interno
+
+La granularidad del paquete se controla con `analysis_depth` (default: 1),
+igual que DistanceAnalyzer.
+
+Umbral en ArchitectAnalystConfig:
+  min_relational_cohesion (default: 1.5) → WARNING si H < umbral
+
+Ticket: Issue #57
+Fecha: 2026-05-27
+"""
+
+import ast
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Dict, List, Set
+
+from quality_agents.architectanalyst.metrics.dependency_graph import DependencyGraphBuilder
+from quality_agents.architectanalyst.models import ArchitectureResult, ArchitectureSeverity
+from quality_agents.architectanalyst.orchestrator import ProjectMetric
+
+
+class RelationalCohesionAnalyzer(ProjectMetric):
+    """
+    Detecta paquetes con baja cohesión relacional (H < min_relational_cohesion).
+
+    Un H bajo indica que las clases del paquete no se usan entre sí —
+    probablemente deberían estar en paquetes distintos.
+
+    Severidad: WARNING si H < min_relational_cohesion.
+    Paquetes con menos de 2 clases se omiten (H no es significativo).
+    """
+
+    def __init__(self) -> None:
+        self._config: Any = None
+
+    @property
+    def name(self) -> str:
+        return "RelationalCohesionAnalyzer"
+
+    @property
+    def category(self) -> str:
+        return "martin"
+
+    @property
+    def estimated_duration(self) -> float:
+        return 3.0
+
+    @property
+    def priority(self) -> int:
+        return 9
+
+    def should_run(self, config: Any) -> bool:
+        self._config = config
+        if config and hasattr(config, "checks"):
+            if not getattr(config.checks, "relational_cohesion", True):
+                return False
+        return True
+
+    def analyze(self, project_path: Path, files: List[Path]) -> List[ArchitectureResult]:
+        config = self._config
+        threshold = getattr(config, "min_relational_cohesion", 1.5) if config else 1.5
+        depth = getattr(config, "analysis_depth", 1) if config else 1
+
+        builder = DependencyGraphBuilder()
+        graph = builder.build(project_path, files)
+
+        python_files = [f for f in files if f.suffix == ".py"]
+        module_to_file = self._build_module_to_file(project_path, python_files, graph.modules)
+
+        package_data = self._compute_package_metrics(graph, module_to_file, depth)
+
+        results: List[ArchitectureResult] = []
+
+        for pkg in sorted(package_data.keys()):
+            n_types = package_data[pkg]["n_types"]
+            r_relations = package_data[pkg]["r_relations"]
+
+            # No significativo con menos de 2 clases
+            if n_types < 2:
+                continue
+
+            h = (r_relations + 1) / n_types
+
+            if h < threshold:
+                results.append(ArchitectureResult(
+                    analyzer_name=self.name,
+                    metric_name="H",
+                    module_path=Path(pkg.replace(".", "/")),
+                    value=round(h, 3),
+                    threshold=threshold,
+                    severity=ArchitectureSeverity.WARNING,
+                    message=(
+                        f"Cohesión Relacional H={h:.2f} < {threshold} en '{pkg}' "
+                        f"(R={r_relations} relaciones internas, N={n_types} tipos). "
+                        f"Las clases del paquete apenas se relacionan entre sí."
+                    ),
+                ))
+
+        return results
+
+    def _compute_package_metrics(
+        self,
+        graph: Any,
+        module_to_file: Dict[str, Path],
+        depth: int,
+    ) -> Dict[str, Dict[str, int]]:
+        """
+        Calcula N (tipos) y R (relaciones internas) por paquete.
+
+        R cuenta pares (módulo_origen, módulo_destino) dentro del mismo paquete.
+        """
+        pkg_modules: Dict[str, Set[str]] = defaultdict(set)
+
+        for module in graph.modules:
+            pkg = ".".join(module.split(".")[:depth])
+            pkg_modules[pkg].add(module)
+
+        result: Dict[str, Dict[str, int]] = {}
+
+        for pkg, modules in pkg_modules.items():
+            # N: total de clases en el paquete
+            n_types = 0
+            for m in modules:
+                file_path = module_to_file.get(m)
+                if file_path:
+                    n_types += self._count_classes(file_path)
+
+            # R: relaciones internas — módulo A del paquete importa módulo B del mismo paquete
+            r_relations = 0
+            for m in modules:
+                for dep in graph.efferent_coupling(m):
+                    dep_pkg = ".".join(dep.split(".")[:depth])
+                    if dep_pkg == pkg and dep != m:
+                        r_relations += 1
+
+            result[pkg] = {"n_types": n_types, "r_relations": r_relations}
+
+        return result
+
+    def _count_classes(self, file_path: Path) -> int:
+        """Cuenta el número de clases definidas en el archivo."""
+        try:
+            source = file_path.read_text(encoding="utf-8")
+            tree = ast.parse(source, filename=str(file_path))
+        except (OSError, SyntaxError):
+            return 0
+        return sum(1 for node in ast.walk(tree) if isinstance(node, ast.ClassDef))
+
+    def _build_module_to_file(
+        self,
+        project_path: Path,
+        files: List[Path],
+        known_modules: Set[str],
+    ) -> Dict[str, Path]:
+        """Construye mapa módulo → Path de archivo."""
+        builder = DependencyGraphBuilder()
+        result: Dict[str, Path] = {}
+        for f in files:
+            name = builder._path_to_module(f, project_path)
+            if name and name in known_modules:
+                result[name] = f
+        return result

--- a/tests/unit/test_architectanalyst_config.py
+++ b/tests/unit/test_architectanalyst_config.py
@@ -254,7 +254,8 @@ sprint_cadence = "2w"
             ArchitectAnalystConfig.from_pyproject_toml(pyproject)
 
         warned_keys = [r.message for r in caplog.records if "desconocida" in r.message]
-        assert any("layer_roles" in msg for msg in warned_keys)
+        # layer_roles es una sección especial reconocida — no genera warning
+        assert not any("layer_roles" in msg for msg in warned_keys)
         assert any("sprint_cadence" in msg for msg in warned_keys)
 
 

--- a/tests/unit/test_architectanalyst_coverage_analyzer.py
+++ b/tests/unit/test_architectanalyst_coverage_analyzer.py
@@ -1,0 +1,201 @@
+"""Tests unitarios para CoverageAnalyzer (#49)."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from quality_agents.architectanalyst.config import (
+    ArchitectAnalystChecksConfig,
+    ArchitectAnalystConfig,
+)
+from quality_agents.architectanalyst.metrics.coverage_analyzer import CoverageAnalyzer
+from quality_agents.architectanalyst.models import ArchitectureSeverity
+
+
+def _config(min_coverage=80.0, report_path="coverage.json", enabled=True):
+    return ArchitectAnalystConfig(
+        min_coverage=min_coverage,
+        coverage_report_path=report_path,
+        checks=ArchitectAnalystChecksConfig(coverage=enabled),
+    )
+
+
+def _write_coverage_json(path: Path, percent: float) -> Path:
+    data = {
+        "meta": {"version": "7.0.0"},
+        "files": {},
+        "totals": {
+            "covered_lines": 100,
+            "num_statements": 100,
+            "percent_covered": percent,
+            "percent_covered_display": str(int(percent)),
+        },
+    }
+    coverage_file = path / "coverage.json"
+    coverage_file.write_text(json.dumps(data), encoding="utf-8")
+    return coverage_file
+
+
+class TestCoverageAnalyzerProperties:
+    def test_name(self):
+        assert CoverageAnalyzer().name == "CoverageAnalyzer"
+
+    def test_category(self):
+        assert CoverageAnalyzer().category == "quality"
+
+    def test_priority(self):
+        assert CoverageAnalyzer().priority == 11
+
+    def test_estimated_duration(self):
+        assert CoverageAnalyzer().estimated_duration == 1.0
+
+
+class TestCoverageShouldRun:
+    def test_runs_by_default(self):
+        a = CoverageAnalyzer()
+        assert a.should_run(_config()) is True
+
+    def test_skips_when_toggle_disabled(self):
+        a = CoverageAnalyzer()
+        assert a.should_run(_config(enabled=False)) is False
+
+    def test_runs_when_toggle_enabled(self):
+        a = CoverageAnalyzer()
+        assert a.should_run(_config(enabled=True)) is True
+
+
+class TestCoverageFileNotFound:
+    def test_warning_when_file_absent(self, tmp_path):
+        a = CoverageAnalyzer()
+        a._config = _config()
+        results = a.analyze(tmp_path, [])
+
+        assert len(results) == 1
+        assert results[0].severity == ArchitectureSeverity.WARNING
+        assert results[0].metric_name == "coverage"
+
+    def test_message_mentions_pytest_command(self, tmp_path):
+        a = CoverageAnalyzer()
+        a._config = _config()
+        results = a.analyze(tmp_path, [])
+
+        assert "pytest" in results[0].message
+
+    def test_custom_path_mentioned_in_message(self, tmp_path):
+        a = CoverageAnalyzer()
+        a._config = _config(report_path="reports/cov.json")
+        results = a.analyze(tmp_path, [])
+
+        assert "reports/cov.json" in results[0].message
+
+
+class TestCoverageInvalidFile:
+    def test_warning_on_invalid_json(self, tmp_path):
+        bad_file = tmp_path / "coverage.json"
+        bad_file.write_text("not json", encoding="utf-8")
+
+        a = CoverageAnalyzer()
+        a._config = _config()
+        results = a.analyze(tmp_path, [])
+
+        assert len(results) == 1
+        assert results[0].severity == ArchitectureSeverity.WARNING
+
+    def test_warning_when_totals_key_missing(self, tmp_path):
+        bad_file = tmp_path / "coverage.json"
+        bad_file.write_text(json.dumps({"meta": {}}), encoding="utf-8")
+
+        a = CoverageAnalyzer()
+        a._config = _config()
+        results = a.analyze(tmp_path, [])
+
+        assert results[0].severity == ArchitectureSeverity.WARNING
+
+
+class TestCoverageResults:
+    def test_info_when_coverage_above_threshold(self, tmp_path):
+        _write_coverage_json(tmp_path, percent=90.0)
+        a = CoverageAnalyzer()
+        a._config = _config(min_coverage=80.0)
+        results = a.analyze(tmp_path, [])
+
+        assert len(results) == 1
+        assert results[0].severity == ArchitectureSeverity.INFO
+        assert results[0].value == pytest.approx(90.0, abs=0.1)
+
+    def test_warning_when_coverage_below_threshold(self, tmp_path):
+        _write_coverage_json(tmp_path, percent=65.0)
+        a = CoverageAnalyzer()
+        a._config = _config(min_coverage=80.0)
+        results = a.analyze(tmp_path, [])
+
+        assert len(results) == 1
+        assert results[0].severity == ArchitectureSeverity.WARNING
+        assert results[0].value == pytest.approx(65.0, abs=0.1)
+
+    def test_info_when_coverage_exactly_at_threshold(self, tmp_path):
+        _write_coverage_json(tmp_path, percent=80.0)
+        a = CoverageAnalyzer()
+        a._config = _config(min_coverage=80.0)
+        results = a.analyze(tmp_path, [])
+
+        assert results[0].severity == ArchitectureSeverity.INFO
+
+    def test_message_contains_percentage(self, tmp_path):
+        _write_coverage_json(tmp_path, percent=75.5)
+        a = CoverageAnalyzer()
+        a._config = _config(min_coverage=80.0)
+        results = a.analyze(tmp_path, [])
+
+        assert "75.5" in results[0].message
+
+    def test_threshold_in_result(self, tmp_path):
+        _write_coverage_json(tmp_path, percent=70.0)
+        a = CoverageAnalyzer()
+        a._config = _config(min_coverage=85.0)
+        results = a.analyze(tmp_path, [])
+
+        assert results[0].threshold == pytest.approx(85.0)
+
+    def test_custom_report_path(self, tmp_path):
+        reports_dir = tmp_path / "reports"
+        reports_dir.mkdir()
+        data = {"totals": {"percent_covered": 92.0}}
+        (reports_dir / "cov.json").write_text(json.dumps(data), encoding="utf-8")
+
+        a = CoverageAnalyzer()
+        a._config = _config(report_path="reports/cov.json")
+        results = a.analyze(tmp_path, [])
+
+        assert results[0].severity == ArchitectureSeverity.INFO
+        assert results[0].value == pytest.approx(92.0, abs=0.1)
+
+
+class TestCoverageConfig:
+    def test_default_min_coverage(self):
+        assert ArchitectAnalystConfig().min_coverage == 80.0
+
+    def test_default_report_path(self):
+        assert ArchitectAnalystConfig().coverage_report_path == "coverage.json"
+
+    def test_default_toggle_enabled(self):
+        assert ArchitectAnalystConfig().checks.coverage is True
+
+    def test_from_pyproject_toml_loads_min_coverage(self, tmp_path):
+        toml = tmp_path / "pyproject.toml"
+        toml.write_text(
+            "[tool.architectanalyst]\n"
+            "min_coverage = 90.0\n"
+        )
+        config = ArchitectAnalystConfig.from_pyproject_toml(toml)
+        assert config.min_coverage == 90.0
+
+    def test_from_pyproject_toml_loads_report_path(self, tmp_path):
+        toml = tmp_path / "pyproject.toml"
+        toml.write_text(
+            "[tool.architectanalyst]\n"
+            'coverage_report_path = "reports/coverage.json"\n'
+        )
+        config = ArchitectAnalystConfig.from_pyproject_toml(toml)
+        assert config.coverage_report_path == "reports/coverage.json"

--- a/tests/unit/test_architectanalyst_distance_analysis_depth.py
+++ b/tests/unit/test_architectanalyst_distance_analysis_depth.py
@@ -1,0 +1,141 @@
+"""Tests unitarios para analysis_depth en DistanceAnalyzer (#48)."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from quality_agents.architectanalyst.config import ArchitectAnalystConfig
+from quality_agents.architectanalyst.metrics.distance_analyzer import DistanceAnalyzer
+
+
+def _config(analysis_depth=1, warn=0.3, crit=0.5):
+    cfg = ArchitectAnalystConfig(
+        max_distance_warning=warn,
+        max_distance_critical=crit,
+        analysis_depth=analysis_depth,
+    )
+    return cfg
+
+
+def _mock_graph(modules, efferent_map=None):
+    """
+    modules: lista de nombres de módulo
+    efferent_map: {module: [deps]} — dependencias efferentes por módulo
+    """
+    efferent_map = efferent_map or {}
+    graph = MagicMock()
+    graph.modules = set(modules)
+    graph.efferent_coupling.side_effect = lambda m: efferent_map.get(m, [])
+    graph.afferent_coupling.side_effect = lambda m: []
+    return graph
+
+
+class TestAggregateToPackagesDepth:
+    def _analyzer(self):
+        a = DistanceAnalyzer()
+        a._config = _config()
+        return a
+
+    def test_depth_1_groups_by_first_component(self):
+        graph = _mock_graph(["myapp.domain.model", "myapp.domain.repo"])
+        result = self._analyzer()._aggregate_to_packages(graph, {}, depth=1)
+        assert "myapp" in result
+        assert "myapp.domain" not in result
+
+    def test_depth_2_groups_by_two_components(self):
+        graph = _mock_graph(["myapp.domain.model", "myapp.infra.db"])
+        result = self._analyzer()._aggregate_to_packages(graph, {}, depth=2)
+        assert "myapp.domain" in result
+        assert "myapp.infra" in result
+        assert "myapp" not in result
+
+    def test_depth_2_separates_subpackages(self):
+        graph = _mock_graph([
+            "myapp.domain.model",
+            "myapp.application.service",
+        ])
+        result = self._analyzer()._aggregate_to_packages(graph, {}, depth=2)
+        assert "myapp.domain" in result
+        assert "myapp.application" in result
+        assert len(result) == 2
+
+    def test_depth_1_default_behavior_unchanged(self):
+        graph = _mock_graph(["a.b.c", "a.b.d", "x.y"])
+        result = self._analyzer()._aggregate_to_packages(graph, {}, depth=1)
+        assert set(result.keys()) == {"a", "x"}
+
+    def test_depth_greater_than_module_length_uses_full_name(self):
+        # module "a" split con depth=3 → ["a"] → pkg = "a"
+        graph = _mock_graph(["a"])
+        result = self._analyzer()._aggregate_to_packages(graph, {}, depth=3)
+        assert "a" in result
+
+    def test_ce_computed_between_packages_at_depth_2(self):
+        # myapp.domain.model depende de myapp.infra.db
+        graph = _mock_graph(
+            ["myapp.domain.model", "myapp.infra.db"],
+            efferent_map={"myapp.domain.model": ["myapp.infra.db"]},
+        )
+        result = self._analyzer()._aggregate_to_packages(graph, {}, depth=2)
+        assert result["myapp.domain"]["ce"] == 1
+        assert result["myapp.infra"]["ca"] == 1
+
+    def test_ce_not_counted_within_same_package_at_depth_2(self):
+        # myapp.domain.model depende de myapp.domain.repo → mismo paquete
+        graph = _mock_graph(
+            ["myapp.domain.model", "myapp.domain.repo"],
+            efferent_map={"myapp.domain.model": ["myapp.domain.repo"]},
+        )
+        result = self._analyzer()._aggregate_to_packages(graph, {}, depth=2)
+        assert result["myapp.domain"]["ce"] == 0
+
+
+class TestAnalysisDepthConfig:
+    def test_default_analysis_depth_is_1(self):
+        config = ArchitectAnalystConfig()
+        assert config.analysis_depth == 1
+
+    def test_analysis_depth_can_be_set(self):
+        config = ArchitectAnalystConfig(analysis_depth=2)
+        assert config.analysis_depth == 2
+
+    def test_from_pyproject_toml_loads_analysis_depth(self, tmp_path):
+        toml = tmp_path / "pyproject.toml"
+        toml.write_text(
+            "[tool.architectanalyst]\n"
+            "analysis_depth = 2\n"
+        )
+        config = ArchitectAnalystConfig.from_pyproject_toml(toml)
+        assert config.analysis_depth == 2
+
+
+class TestDistanceAnalyzerUsesDepth:
+    def test_analyze_passes_depth_to_aggregator(self, tmp_path):
+        analyzer = DistanceAnalyzer()
+        analyzer._config = _config(analysis_depth=2)
+
+        with patch.object(
+            analyzer, "_aggregate_to_packages", wraps=analyzer._aggregate_to_packages
+        ) as mock_agg, patch(
+            "quality_agents.architectanalyst.metrics.distance_analyzer.DependencyGraphBuilder"
+        ) as MockBuilder:
+            MockBuilder.return_value.build.return_value = _mock_graph([])
+            analyzer.analyze(tmp_path, [])
+
+        mock_agg.assert_called_once()
+        _, kwargs = mock_agg.call_args
+        assert kwargs.get("depth", mock_agg.call_args[0][2] if len(mock_agg.call_args[0]) > 2 else 1) == 2
+
+    def test_depth_1_produces_same_results_as_before(self, tmp_path):
+        """Con depth=1 el comportamiento es idéntico al original."""
+        analyzer = DistanceAnalyzer()
+        analyzer._config = _config(analysis_depth=1)
+
+        with patch(
+            "quality_agents.architectanalyst.metrics.distance_analyzer.DependencyGraphBuilder"
+        ) as MockBuilder:
+            MockBuilder.return_value.build.return_value = _mock_graph([])
+            results = analyzer.analyze(tmp_path, [])
+
+        assert results == []

--- a/tests/unit/test_architectanalyst_god_package.py
+++ b/tests/unit/test_architectanalyst_god_package.py
@@ -1,0 +1,254 @@
+"""Tests unitarios para GodPackageAnalyzer (#58)."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from quality_agents.architectanalyst.config import (
+    ArchitectAnalystChecksConfig,
+    ArchitectAnalystConfig,
+)
+from quality_agents.architectanalyst.metrics.god_package_analyzer import GodPackageAnalyzer
+from quality_agents.architectanalyst.models import ArchitectureSeverity
+
+
+def _config(max_classes=20, max_ca=10, depth=1, enabled=True):
+    return ArchitectAnalystConfig(
+        max_package_classes=max_classes,
+        max_package_ca=max_ca,
+        analysis_depth=depth,
+        checks=ArchitectAnalystChecksConfig(god_package=enabled),
+    )
+
+
+def _mock_graph(modules, efferent_map=None):
+    efferent_map = efferent_map or {}
+    graph = MagicMock()
+    graph.modules = set(modules)
+    graph.efferent_coupling.side_effect = lambda m: efferent_map.get(m, [])
+    return graph
+
+
+class TestGodPackageAnalyzerProperties:
+    def test_name(self):
+        assert GodPackageAnalyzer().name == "GodPackageAnalyzer"
+
+    def test_category(self):
+        assert GodPackageAnalyzer().category == "smells"
+
+    def test_priority(self):
+        assert GodPackageAnalyzer().priority == 10
+
+    def test_estimated_duration(self):
+        assert GodPackageAnalyzer().estimated_duration == 3.0
+
+
+class TestGodPackageShouldRun:
+    def test_runs_by_default(self):
+        a = GodPackageAnalyzer()
+        assert a.should_run(_config()) is True
+
+    def test_skips_when_toggle_disabled(self):
+        a = GodPackageAnalyzer()
+        assert a.should_run(_config(enabled=False)) is False
+
+    def test_runs_when_toggle_enabled(self):
+        a = GodPackageAnalyzer()
+        assert a.should_run(_config(enabled=True)) is True
+
+
+class TestComputePackageData:
+    def test_empty_graph_returns_empty(self):
+        graph = _mock_graph([])
+        a = GodPackageAnalyzer()
+        result = a._compute_package_data(graph, {}, depth=1)
+        assert result == {}
+
+    def test_single_module_no_ca(self):
+        graph = _mock_graph(["pkg.a"])
+        a = GodPackageAnalyzer()
+        result = a._compute_package_data(graph, {}, depth=1)
+        assert result["pkg"]["ca"] == 0
+
+    def test_ca_counted_when_other_package_imports(self):
+        graph = _mock_graph(
+            ["pkg.a", "other.b"],
+            efferent_map={"other.b": ["pkg.a"]},
+        )
+        a = GodPackageAnalyzer()
+        result = a._compute_package_data(graph, {}, depth=1)
+        assert result["pkg"]["ca"] == 1
+        assert result["other"]["ca"] == 0
+
+    def test_ca_counts_distinct_packages_not_modules(self):
+        # Dos módulos del mismo paquete importan pkg.a → Ca=1, no 2
+        graph = _mock_graph(
+            ["pkg.a", "other.b", "other.c"],
+            efferent_map={"other.b": ["pkg.a"], "other.c": ["pkg.a"]},
+        )
+        a = GodPackageAnalyzer()
+        result = a._compute_package_data(graph, {}, depth=1)
+        assert result["pkg"]["ca"] == 1
+
+    def test_internal_imports_not_counted_in_ca(self):
+        graph = _mock_graph(
+            ["pkg.a", "pkg.b"],
+            efferent_map={"pkg.a": ["pkg.b"]},
+        )
+        a = GodPackageAnalyzer()
+        result = a._compute_package_data(graph, {}, depth=1)
+        assert result["pkg"]["ca"] == 0
+
+    def test_depth_2_groups_correctly(self):
+        graph = _mock_graph(
+            ["myapp.domain.a", "myapp.infra.b"],
+            efferent_map={"myapp.infra.b": ["myapp.domain.a"]},
+        )
+        a = GodPackageAnalyzer()
+        result = a._compute_package_data(graph, {}, depth=2)
+        assert result["myapp.domain"]["ca"] == 1
+        assert result["myapp.infra"]["ca"] == 0
+
+    def test_n_classes_zero_when_no_file(self):
+        graph = _mock_graph(["pkg.a"])
+        a = GodPackageAnalyzer()
+        result = a._compute_package_data(graph, {}, depth=1)
+        assert result["pkg"]["n_classes"] == 0
+
+    def test_multiple_ca_packages(self):
+        graph = _mock_graph(
+            ["core.a", "svc1.b", "svc2.c", "svc3.d"],
+            efferent_map={
+                "svc1.b": ["core.a"],
+                "svc2.c": ["core.a"],
+                "svc3.d": ["core.a"],
+            },
+        )
+        a = GodPackageAnalyzer()
+        result = a._compute_package_data(graph, {}, depth=1)
+        assert result["core"]["ca"] == 3
+
+
+class TestGodPackageAnalyze:
+    def test_no_result_below_both_thresholds(self, tmp_path):
+        a = GodPackageAnalyzer()
+        a._config = _config(max_classes=20, max_ca=10)
+
+        with patch.object(a, "_compute_package_data", return_value={
+            "mypkg": {"n_classes": 5, "ca": 3}
+        }), patch(
+            "quality_agents.architectanalyst.metrics.god_package_analyzer.DependencyGraphBuilder"
+        ) as MockB:
+            MockB.return_value.build.return_value = MagicMock(modules=set())
+            results = a.analyze(tmp_path, [])
+
+        assert results == []
+
+    def test_warning_when_classes_exceed_threshold(self, tmp_path):
+        a = GodPackageAnalyzer()
+        a._config = _config(max_classes=10, max_ca=100)
+
+        with patch.object(a, "_compute_package_data", return_value={
+            "mypkg": {"n_classes": 25, "ca": 2}
+        }), patch(
+            "quality_agents.architectanalyst.metrics.god_package_analyzer.DependencyGraphBuilder"
+        ) as MockB:
+            MockB.return_value.build.return_value = MagicMock(modules=set())
+            results = a.analyze(tmp_path, [])
+
+        assert len(results) == 1
+        assert results[0].metric_name == "GodPackage.Classes"
+        assert results[0].severity == ArchitectureSeverity.WARNING
+        assert results[0].value == 25.0
+
+    def test_warning_when_ca_exceeds_threshold(self, tmp_path):
+        a = GodPackageAnalyzer()
+        a._config = _config(max_classes=100, max_ca=5)
+
+        with patch.object(a, "_compute_package_data", return_value={
+            "mypkg": {"n_classes": 3, "ca": 12}
+        }), patch(
+            "quality_agents.architectanalyst.metrics.god_package_analyzer.DependencyGraphBuilder"
+        ) as MockB:
+            MockB.return_value.build.return_value = MagicMock(modules=set())
+            results = a.analyze(tmp_path, [])
+
+        assert len(results) == 1
+        assert results[0].metric_name == "GodPackage.Ca"
+        assert results[0].severity == ArchitectureSeverity.WARNING
+        assert results[0].value == 12.0
+
+    def test_two_warnings_when_both_exceed_threshold(self, tmp_path):
+        a = GodPackageAnalyzer()
+        a._config = _config(max_classes=10, max_ca=5)
+
+        with patch.object(a, "_compute_package_data", return_value={
+            "mypkg": {"n_classes": 30, "ca": 15}
+        }), patch(
+            "quality_agents.architectanalyst.metrics.god_package_analyzer.DependencyGraphBuilder"
+        ) as MockB:
+            MockB.return_value.build.return_value = MagicMock(modules=set())
+            results = a.analyze(tmp_path, [])
+
+        assert len(results) == 2
+        metric_names = {r.metric_name for r in results}
+        assert metric_names == {"GodPackage.Classes", "GodPackage.Ca"}
+
+    def test_message_contains_package_name_and_values(self, tmp_path):
+        a = GodPackageAnalyzer()
+        a._config = _config(max_classes=10, max_ca=100)
+
+        with patch.object(a, "_compute_package_data", return_value={
+            "mypkg": {"n_classes": 25, "ca": 2}
+        }), patch(
+            "quality_agents.architectanalyst.metrics.god_package_analyzer.DependencyGraphBuilder"
+        ) as MockB:
+            MockB.return_value.build.return_value = MagicMock(modules=set())
+            results = a.analyze(tmp_path, [])
+
+        assert "mypkg" in results[0].message
+        assert "25" in results[0].message
+
+    def test_exactly_at_threshold_no_warning(self, tmp_path):
+        a = GodPackageAnalyzer()
+        a._config = _config(max_classes=20, max_ca=10)
+
+        with patch.object(a, "_compute_package_data", return_value={
+            "mypkg": {"n_classes": 20, "ca": 10}
+        }), patch(
+            "quality_agents.architectanalyst.metrics.god_package_analyzer.DependencyGraphBuilder"
+        ) as MockB:
+            MockB.return_value.build.return_value = MagicMock(modules=set())
+            results = a.analyze(tmp_path, [])
+
+        assert results == []
+
+
+class TestGodPackageConfig:
+    def test_default_max_package_classes(self):
+        assert ArchitectAnalystConfig().max_package_classes == 20
+
+    def test_default_max_package_ca(self):
+        assert ArchitectAnalystConfig().max_package_ca == 10
+
+    def test_default_toggle_enabled(self):
+        assert ArchitectAnalystConfig().checks.god_package is True
+
+    def test_from_pyproject_toml_loads_max_package_classes(self, tmp_path):
+        toml = tmp_path / "pyproject.toml"
+        toml.write_text(
+            "[tool.architectanalyst]\n"
+            "max_package_classes = 30\n"
+        )
+        config = ArchitectAnalystConfig.from_pyproject_toml(toml)
+        assert config.max_package_classes == 30
+
+    def test_from_pyproject_toml_loads_max_package_ca(self, tmp_path):
+        toml = tmp_path / "pyproject.toml"
+        toml.write_text(
+            "[tool.architectanalyst]\n"
+            "max_package_ca = 15\n"
+        )
+        config = ArchitectAnalystConfig.from_pyproject_toml(toml)
+        assert config.max_package_ca == 15

--- a/tests/unit/test_architectanalyst_instability_layer_roles.py
+++ b/tests/unit/test_architectanalyst_instability_layer_roles.py
@@ -1,0 +1,183 @@
+"""Tests unitarios para layer_roles en InstabilityAnalyzer (#47)."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from quality_agents.architectanalyst.config import ArchitectAnalystConfig
+from quality_agents.architectanalyst.metrics.instability_analyzer import InstabilityAnalyzer
+from quality_agents.architectanalyst.models import ArchitectureSeverity
+
+
+def _config(max_instability=0.8, layer_roles=None):
+    cfg = ArchitectAnalystConfig(max_instability=max_instability)
+    cfg.layer_roles = layer_roles or {}
+    return cfg
+
+
+def _mock_graph(modules_data):
+    """
+    modules_data: {module_name: (ca, ce)}
+    """
+    graph = MagicMock()
+    graph.modules = list(modules_data.keys())
+    graph.afferent_coupling.side_effect = lambda m: list(range(modules_data[m][0]))
+    graph.efferent_coupling.side_effect = lambda m: list(range(modules_data[m][1]))
+    return graph
+
+
+class TestResolveRole:
+    def test_no_roles_returns_none(self):
+        a = InstabilityAnalyzer()
+        assert a._resolve_role("myapp.domain.model", {}) is None
+
+    def test_matches_glob_pattern(self):
+        a = InstabilityAnalyzer()
+        roles = {"*/domain/*": "stable"}
+        assert a._resolve_role("myapp.domain.model", roles) == "stable"
+
+    def test_matches_leaf_role(self):
+        a = InstabilityAnalyzer()
+        roles = {"*/commands/*": "leaf"}
+        assert a._resolve_role("myapp.application.commands.create", roles) == "leaf"
+
+    def test_no_match_returns_none(self):
+        a = InstabilityAnalyzer()
+        roles = {"*/domain/*": "stable"}
+        assert a._resolve_role("myapp.infrastructure.db", roles) is None
+
+    def test_invalid_role_ignored(self):
+        a = InstabilityAnalyzer()
+        roles = {"*/domain/*": "unknown_role"}
+        assert a._resolve_role("myapp.domain.model", roles) is None
+
+    def test_dots_converted_to_slashes_for_matching(self):
+        a = InstabilityAnalyzer()
+        roles = {"myapp/domain/*": "stable"}
+        assert a._resolve_role("myapp.domain.model", roles) == "stable"
+
+
+class TestEvaluarModulo:
+    def test_no_role_warns_when_above_threshold(self):
+        a = InstabilityAnalyzer()
+        result = a._evaluar_modulo("myapp.foo", 0.9, ca=0, ce=5, threshold=0.8, role=None)
+        assert result is not None
+        assert result.severity == ArchitectureSeverity.WARNING
+
+    def test_no_role_no_result_when_below_threshold(self):
+        a = InstabilityAnalyzer()
+        result = a._evaluar_modulo("myapp.foo", 0.5, ca=3, ce=2, threshold=0.8, role=None)
+        assert result is None
+
+    def test_stable_role_same_as_no_role(self):
+        a = InstabilityAnalyzer()
+        result = a._evaluar_modulo("myapp.foo", 0.9, ca=0, ce=5, threshold=0.8, role="stable")
+        assert result is not None
+        assert "rol: stable" in result.message
+
+    def test_leaf_warns_when_i_too_low(self):
+        a = InstabilityAnalyzer()
+        # leaf threshold = 1.0 - 0.8 = 0.2
+        # I=0.1 < 0.2 → warning
+        result = a._evaluar_modulo("myapp.cmds.create", 0.1, ca=5, ce=0, threshold=0.8, role="leaf")
+        assert result is not None
+        assert result.severity == ArchitectureSeverity.WARNING
+        assert "Leaf module" in result.message
+
+    def test_leaf_no_result_when_i_is_high(self):
+        a = InstabilityAnalyzer()
+        # leaf threshold = 0.2; I=0.9 > 0.2 → no violation for leaf
+        result = a._evaluar_modulo("myapp.cmds.create", 0.9, ca=0, ce=5, threshold=0.8, role="leaf")
+        assert result is None
+
+    def test_leaf_threshold_boundary(self):
+        a = InstabilityAnalyzer()
+        # leaf threshold = 0.2; I=0.2 exactly → no violation (not strictly less)
+        result = a._evaluar_modulo("myapp.cmds", 0.2, ca=2, ce=8, threshold=0.8, role="leaf")
+        assert result is None
+
+
+class TestInstabilityAnalyzerWithLayerRoles:
+    def test_analyze_without_layer_roles_unchanged(self, tmp_path):
+        analyzer = InstabilityAnalyzer()
+        analyzer._config = _config()
+
+        with patch(
+            "quality_agents.architectanalyst.metrics.instability_analyzer.DependencyGraphBuilder"
+        ) as MockBuilder:
+            MockBuilder.return_value.build.return_value = _mock_graph({
+                "myapp.foo": (0, 5),  # I=1.0 > 0.8 → warning
+                "myapp.bar": (3, 1),  # I=0.25 < 0.8 → no warning
+            })
+            results = analyzer.analyze(tmp_path, [])
+
+        assert len(results) == 1
+        assert results[0].value == 1.0
+
+    def test_analyze_leaf_module_warns_when_too_stable(self, tmp_path):
+        analyzer = InstabilityAnalyzer()
+        analyzer._config = _config(layer_roles={"myapp/commands/*": "leaf"})
+
+        with patch(
+            "quality_agents.architectanalyst.metrics.instability_analyzer.DependencyGraphBuilder"
+        ) as MockBuilder:
+            MockBuilder.return_value.build.return_value = _mock_graph({
+                "myapp.commands.create": (5, 0),  # I=0.0 < 0.2 → leaf warning
+            })
+            results = analyzer.analyze(tmp_path, [])
+
+        assert len(results) == 1
+        assert "Leaf module" in results[0].message
+
+    def test_analyze_leaf_module_no_warning_when_unstable(self, tmp_path):
+        analyzer = InstabilityAnalyzer()
+        analyzer._config = _config(layer_roles={"myapp/commands/*": "leaf"})
+
+        with patch(
+            "quality_agents.architectanalyst.metrics.instability_analyzer.DependencyGraphBuilder"
+        ) as MockBuilder:
+            MockBuilder.return_value.build.return_value = _mock_graph({
+                "myapp.commands.create": (0, 5),  # I=1.0 → leaf OK
+            })
+            results = analyzer.analyze(tmp_path, [])
+
+        assert results == []
+
+    def test_analyze_isolated_modules_skipped(self, tmp_path):
+        analyzer = InstabilityAnalyzer()
+        analyzer._config = _config()
+
+        with patch(
+            "quality_agents.architectanalyst.metrics.instability_analyzer.DependencyGraphBuilder"
+        ) as MockBuilder:
+            MockBuilder.return_value.build.return_value = _mock_graph({
+                "myapp.isolated": (0, 0),
+            })
+            results = analyzer.analyze(tmp_path, [])
+
+        assert results == []
+
+
+class TestLayerRolesConfig:
+    def test_default_layer_roles_is_empty(self):
+        config = ArchitectAnalystConfig()
+        assert config.layer_roles == {}
+
+    def test_layer_roles_can_be_set(self):
+        config = ArchitectAnalystConfig()
+        config.layer_roles = {"*/domain/*": "stable", "*/commands/*": "leaf"}
+        assert config.layer_roles["*/domain/*"] == "stable"
+
+    def test_from_pyproject_toml_loads_layer_roles(self, tmp_path):
+        toml = tmp_path / "pyproject.toml"
+        toml.write_text(
+            "[tool.architectanalyst]\n"
+            "[tool.architectanalyst.layer_roles]\n"
+            '"*/domain/*" = "stable"\n'
+            '"*/commands/*" = "leaf"\n'
+        )
+        from quality_agents.architectanalyst.config import ArchitectAnalystConfig as Cfg
+        config = Cfg.from_pyproject_toml(toml)
+        assert config.layer_roles["*/domain/*"] == "stable"
+        assert config.layer_roles["*/commands/*"] == "leaf"

--- a/tests/unit/test_architectanalyst_orchestrator.py
+++ b/tests/unit/test_architectanalyst_orchestrator.py
@@ -274,12 +274,17 @@ class TestMetricOrchestratorRun:
         assert orch.run([]) == []
 
     def test_run_sin_metricas_retorna_vacia(self, tmp_path):
-        """Sin métricas descubiertas, run() debe retornar []."""
+        """Con código trivial y cobertura OK, no debe haber violaciones."""
+        import json
         py_file = tmp_path / "module.py"
         py_file.write_text("x = 1")
+        (tmp_path / "coverage.json").write_text(
+            json.dumps({"totals": {"percent_covered": 100.0}}), encoding="utf-8"
+        )
         orch = MetricOrchestrator(config=None)
 
-        assert orch.run([py_file]) == []
+        results = orch.run([py_file])
+        assert [r for r in results if r.has_violation()] == []
 
     def test_run_ignora_archivos_no_python(self, tmp_path):
         """Archivos que no son .py no deben ser pasados a las métricas."""
@@ -438,14 +443,18 @@ class TestArchitectAnalyst:
         assert analyst.run(files=[]) == []
 
     def test_run_sin_metricas_retorna_vacia(self, tmp_path):
-        """Sin métricas descubiertas, run() retorna []."""
+        """Con código trivial y cobertura OK, no debe haber violaciones."""
+        import json
         py_file = tmp_path / "module.py"
         py_file.write_text("x = 1")
+        (tmp_path / "coverage.json").write_text(
+            json.dumps({"totals": {"percent_covered": 100.0}}), encoding="utf-8"
+        )
 
         analyst = ArchitectAnalyst(path=tmp_path)
         results = analyst.run(files=[py_file])
 
-        assert results == []
+        assert [r for r in results if r.has_violation()] == []
 
     def test_has_violations_sin_resultados(self):
         """has_violations() debe ser False sin resultados."""

--- a/tests/unit/test_architectanalyst_relational_cohesion.py
+++ b/tests/unit/test_architectanalyst_relational_cohesion.py
@@ -1,0 +1,199 @@
+"""Tests unitarios para RelationalCohesionAnalyzer (#57)."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from quality_agents.architectanalyst.config import (
+    ArchitectAnalystChecksConfig,
+    ArchitectAnalystConfig,
+)
+from quality_agents.architectanalyst.metrics.relational_cohesion_analyzer import (
+    RelationalCohesionAnalyzer,
+)
+from quality_agents.architectanalyst.models import ArchitectureSeverity
+
+
+def _config(min_h=1.5, depth=1, enabled=True):
+    cfg = ArchitectAnalystConfig(
+        min_relational_cohesion=min_h,
+        analysis_depth=depth,
+        checks=ArchitectAnalystChecksConfig(relational_cohesion=enabled),
+    )
+    return cfg
+
+
+def _mock_graph(modules, efferent_map=None):
+    efferent_map = efferent_map or {}
+    graph = MagicMock()
+    graph.modules = set(modules)
+    graph.efferent_coupling.side_effect = lambda m: efferent_map.get(m, [])
+    return graph
+
+
+class TestRelationalCohesionAnalyzerProperties:
+    def test_name(self):
+        assert RelationalCohesionAnalyzer().name == "RelationalCohesionAnalyzer"
+
+    def test_category(self):
+        assert RelationalCohesionAnalyzer().category == "martin"
+
+    def test_priority(self):
+        assert RelationalCohesionAnalyzer().priority == 9
+
+    def test_estimated_duration(self):
+        assert RelationalCohesionAnalyzer().estimated_duration == 3.0
+
+
+class TestRelationalCohesionShouldRun:
+    def test_runs_by_default(self):
+        a = RelationalCohesionAnalyzer()
+        assert a.should_run(_config()) is True
+
+    def test_skips_when_toggle_disabled(self):
+        a = RelationalCohesionAnalyzer()
+        assert a.should_run(_config(enabled=False)) is False
+
+    def test_runs_when_toggle_enabled(self):
+        a = RelationalCohesionAnalyzer()
+        assert a.should_run(_config(enabled=True)) is True
+
+
+class TestComputePackageMetrics:
+    def test_single_module_no_relations(self):
+        graph = _mock_graph(["pkg.a"])
+        a = RelationalCohesionAnalyzer()
+        result = a._compute_package_metrics(graph, {}, depth=1)
+        assert result["pkg"]["r_relations"] == 0
+
+    def test_internal_relation_counted(self):
+        graph = _mock_graph(
+            ["pkg.a", "pkg.b"],
+            efferent_map={"pkg.a": ["pkg.b"]},
+        )
+        a = RelationalCohesionAnalyzer()
+        result = a._compute_package_metrics(graph, {}, depth=1)
+        assert result["pkg"]["r_relations"] == 1
+
+    def test_external_relation_not_counted(self):
+        graph = _mock_graph(
+            ["pkg.a", "other.b"],
+            efferent_map={"pkg.a": ["other.b"]},
+        )
+        a = RelationalCohesionAnalyzer()
+        result = a._compute_package_metrics(graph, {}, depth=1)
+        assert result["pkg"]["r_relations"] == 0
+
+    def test_bidirectional_relations_counted_separately(self):
+        graph = _mock_graph(
+            ["pkg.a", "pkg.b"],
+            efferent_map={"pkg.a": ["pkg.b"], "pkg.b": ["pkg.a"]},
+        )
+        a = RelationalCohesionAnalyzer()
+        result = a._compute_package_metrics(graph, {}, depth=1)
+        assert result["pkg"]["r_relations"] == 2
+
+    def test_depth_2_groups_correctly(self):
+        graph = _mock_graph(
+            ["myapp.domain.a", "myapp.domain.b"],
+            efferent_map={"myapp.domain.a": ["myapp.domain.b"]},
+        )
+        a = RelationalCohesionAnalyzer()
+        result = a._compute_package_metrics(graph, {}, depth=2)
+        assert result["myapp.domain"]["r_relations"] == 1
+
+
+class TestRelationalCohesionExecute:
+    def test_no_result_when_package_has_fewer_than_2_classes(self, tmp_path):
+        a = RelationalCohesionAnalyzer()
+        a._config = _config()
+
+        with patch.object(a, "_compute_package_metrics", return_value={
+            "mypkg": {"n_types": 1, "r_relations": 0}
+        }), patch(
+            "quality_agents.architectanalyst.metrics.relational_cohesion_analyzer.DependencyGraphBuilder"
+        ) as MockB:
+            MockB.return_value.build.return_value = MagicMock(modules=set())
+            results = a.analyze(tmp_path, [])
+
+        assert results == []
+
+    def test_warning_when_h_below_threshold(self, tmp_path):
+        a = RelationalCohesionAnalyzer()
+        a._config = _config(min_h=1.5)
+
+        # H = (0 + 1) / 3 = 0.33 < 1.5 → warning
+        with patch.object(a, "_compute_package_metrics", return_value={
+            "mypkg": {"n_types": 3, "r_relations": 0}
+        }), patch(
+            "quality_agents.architectanalyst.metrics.relational_cohesion_analyzer.DependencyGraphBuilder"
+        ) as MockB:
+            MockB.return_value.build.return_value = MagicMock(modules=set())
+            results = a.analyze(tmp_path, [])
+
+        assert len(results) == 1
+        assert results[0].severity == ArchitectureSeverity.WARNING
+        assert results[0].metric_name == "H"
+
+    def test_no_result_when_h_above_threshold(self, tmp_path):
+        a = RelationalCohesionAnalyzer()
+        a._config = _config(min_h=1.5)
+
+        # H = (5 + 1) / 3 = 2.0 >= 1.5 → no warning
+        with patch.object(a, "_compute_package_metrics", return_value={
+            "mypkg": {"n_types": 3, "r_relations": 5}
+        }), patch(
+            "quality_agents.architectanalyst.metrics.relational_cohesion_analyzer.DependencyGraphBuilder"
+        ) as MockB:
+            MockB.return_value.build.return_value = MagicMock(modules=set())
+            results = a.analyze(tmp_path, [])
+
+        assert results == []
+
+    def test_h_value_in_result(self, tmp_path):
+        a = RelationalCohesionAnalyzer()
+        a._config = _config(min_h=1.5)
+
+        # H = (1 + 1) / 4 = 0.5
+        with patch.object(a, "_compute_package_metrics", return_value={
+            "mypkg": {"n_types": 4, "r_relations": 1}
+        }), patch(
+            "quality_agents.architectanalyst.metrics.relational_cohesion_analyzer.DependencyGraphBuilder"
+        ) as MockB:
+            MockB.return_value.build.return_value = MagicMock(modules=set())
+            results = a.analyze(tmp_path, [])
+
+        assert results[0].value == pytest.approx(0.5, abs=0.01)
+
+    def test_message_contains_h_r_n(self, tmp_path):
+        a = RelationalCohesionAnalyzer()
+        a._config = _config(min_h=1.5)
+
+        with patch.object(a, "_compute_package_metrics", return_value={
+            "mypkg": {"n_types": 3, "r_relations": 0}
+        }), patch(
+            "quality_agents.architectanalyst.metrics.relational_cohesion_analyzer.DependencyGraphBuilder"
+        ) as MockB:
+            MockB.return_value.build.return_value = MagicMock(modules=set())
+            results = a.analyze(tmp_path, [])
+
+        assert "R=0" in results[0].message
+        assert "N=3" in results[0].message
+
+
+class TestRelationalCohesionConfig:
+    def test_default_min_relational_cohesion(self):
+        assert ArchitectAnalystConfig().min_relational_cohesion == 1.5
+
+    def test_default_toggle_enabled(self):
+        assert ArchitectAnalystConfig().checks.relational_cohesion is True
+
+    def test_from_pyproject_toml_loads_min_relational_cohesion(self, tmp_path):
+        toml = tmp_path / "pyproject.toml"
+        toml.write_text(
+            "[tool.architectanalyst]\n"
+            "min_relational_cohesion = 2.0\n"
+        )
+        config = ArchitectAnalystConfig.from_pyproject_toml(toml)
+        assert config.min_relational_cohesion == 2.0


### PR DESCRIPTION
## Resumen

5 mejoras para ArchitectAnalyst como parte del Incremento 4 del plan v0.4.0.

- **#47** `layer_roles` en `InstabilityAnalyzer` — calibración por rol de módulo (`leaf`/`stable`) vía fnmatch, útil para arquitecturas CQRS/ES/Hexagonal
- **#48** `analysis_depth` en `DistanceAnalyzer` — granularidad de paquete configurable (depth=1 top-level, depth=2 sub-paquetes), retrocompatible
- **#57** `RelationalCohesionAnalyzer` — métrica H = (R+1)/N de Robert C. Martin; WARNING si H < `min_relational_cohesion` (default 1.5)
- **#58** `GodPackageAnalyzer` — detecta God Packages por exceso de clases (`max_package_classes`, default 20) o Ca excesivo (`max_package_ca`, default 10)
- **#49** `CoverageAnalyzer` — lee `coverage.json` de pytest-cov; WARNING si cobertura < `min_coverage` (default 80%) o si el archivo no existe

## Cambios principales

- 3 nuevos analyzers (`RelationalCohesionAnalyzer`, `GodPackageAnalyzer`, `CoverageAnalyzer`)
- 2 analyzers extendidos (`InstabilityAnalyzer`, `DistanceAnalyzer`)
- 5 nuevos toggles en `ArchitectAnalystChecksConfig`
- 6 nuevas claves en `ArchitectAnalystConfig`
- 69 tests unitarios nuevos

## Plan de tests

- [x] `pytest tests/unit/test_architectanalyst_*.py` — 350 pasando
- [x] `ruff check src/quality_agents/architectanalyst/` — sin errores
- [x] `mypy src/quality_agents/architectanalyst/` — sin errores

🤖 Generated with [Claude Code](https://claude.com/claude-code)