### PR TITLE
feat #66: configuración explícita de los 3 agentes en pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,31 +125,104 @@ exclude = [".venv", "venv", "__pycache__", "migrations"]
 select = ["E", "F", "W", "I", "N", "B", "C4"]
 ignore = ["E501"]  # Line too long (handled by formatter)
 
+[tool.codeguard]
+min_pylint_score          = 8.0
+max_cyclomatic_complexity = 10
+max_line_length           = 100
+max_function_lines        = 20
+min_dead_code_confidence  = 60
+min_maintainability_index = 20
+exclude_patterns          = ["*.pyc", "__pycache__", ".venv", "venv", "migrations"]
+
+[tool.codeguard.checks]
+pep8            = true
+pylint          = true
+security        = true
+complexity      = true
+types           = true
+imports         = true
+dead_code       = true
+maintainability = true
+spelling        = true
+
+[tool.codeguard.ai]
+enabled        = false
+explain_errors = true
+suggest_fixes  = true
+max_tokens     = 500
+
 [tool.designreviewer]
-max_cbo = 5
-max_fan_out = 7
-max_dit = 5
-max_nop = 1
-max_lcom = 1
-max_wmc = 20
+max_cbo                    = 5
+max_fan_out                = 7
+max_dit                    = 5
+max_nop                    = 1
+max_lcom                   = 1
+max_wmc                    = 20
+max_god_object_methods     = 20
+max_god_object_lines       = 300
+max_method_lines           = 20
+max_parameters             = 5
+min_data_clump_size        = 3
+min_data_clump_occurrences = 2
+max_demeter_depth          = 1
+max_primitive_params       = 3
+exclude_patterns           = ["__pycache__", ".venv", "venv", "migrations", "test_", "conftest"]
+
+[tool.designreviewer.checks]
+cbo                 = true
+fan_out             = true
+circular_imports    = true
+lcom                = true
+wmc                 = true
+dit                 = true
+nop                 = true
+god_object          = true
+long_method         = true
+long_parameter_list = true
+feature_envy        = true
+data_clumps         = true
+law_of_demeter      = true
+primitive_obsession = true
 
 [tool.designreviewer.ai]
-enabled = false
+enabled             = false
+suggest_refactoring = true
+max_tokens          = 800
 
 [tool.architectanalyst]
-max_instability = 0.8
-max_distance_warning = 0.3
-max_distance_critical = 0.5
-db_path = ".quality_control/architecture.db"
+max_instability        = 0.8
+max_distance_warning   = 0.3
+max_distance_critical  = 0.5
+db_path                = ".quality_control/architecture.db"
+min_relational_cohesion = 1.5
+analysis_depth         = 1
+max_package_classes    = 20
+max_package_ca         = 10
+min_coverage           = 80.0
+coverage_report_path   = "coverage.json"
+exclude_patterns       = ["__pycache__", ".venv", "venv", "migrations", "test_", "conftest", "dist", "build"]
+
+[tool.architectanalyst.checks]
+coupling          = true
+abstractness      = true
+instability       = true
+distance          = true
+dependency_cycles = true
+layer_violations  = true
+relational_cohesion = true
+god_package       = true
+coverage          = true
+
+[tool.architectanalyst.layers]
+# Arquitectura de quality_agents: cada agente es independiente.
+# Descomentar y adaptar para proyectos con arquitectura en capas explícita:
+# domain         = []
+# application    = ["domain"]
+# infrastructure = ["application", "domain"]
 
 [tool.architectanalyst.ai]
-enabled = false
-
-# Ejemplo de configuración de capas (descomentar y adaptar a tu proyecto):
-# [tool.architectanalyst.layers]
-# domain = []
-# application = ["domain"]
-# infrastructure = ["application", "domain"]
+enabled    = false
+max_tokens = 1500
 
 [tool.mypy]
 python_version = "3.11"

--- a/tests/unit/test_architectanalyst_config.py
+++ b/tests/unit/test_architectanalyst_config.py
@@ -4,6 +4,8 @@ Tests unitarios para ArchitectAnalystConfig, AIConfig, LayersConfig y load_confi
 Ticket: 1.6
 """
 
+from pathlib import Path
+
 import pytest
 
 from quality_agents.architectanalyst.config import (
@@ -325,5 +327,42 @@ max_line_length = 100
         config = load_config()
 
         assert isinstance(config, ArchitectAnalystConfig)
+
+
+class TestLoadConfigFromProjectPyproject:
+    """Verifica que load_config() lee correctamente el pyproject.toml real del proyecto."""
+
+    def _project_root(self) -> Path:
+        return Path(__file__).parent.parent.parent
+
+    def test_carga_desde_pyproject_toml_real(self):
+        config = load_config(project_root=self._project_root())
+        assert isinstance(config, ArchitectAnalystConfig)
+
+    def test_campos_basicos_leidos(self):
+        config = load_config(project_root=self._project_root())
+        assert config.max_instability == 0.8
+        assert config.max_distance_warning == 0.3
+        assert config.max_distance_critical == 0.5
+
+    def test_nuevos_campos_v04_leidos(self):
+        config = load_config(project_root=self._project_root())
+        assert config.min_relational_cohesion == 1.5
+        assert config.max_package_classes == 20
+        assert config.max_package_ca == 10
+        assert config.min_coverage == 80.0
+        assert config.coverage_report_path == "coverage.json"
+        assert config.analysis_depth == 1
+
+    def test_checks_leidos_desde_archivo(self):
+        config = load_config(project_root=self._project_root())
+        assert config.checks.relational_cohesion is True
+        assert config.checks.god_package is True
+        assert config.checks.coverage is True
+
+    def test_ai_leido_desde_archivo(self):
+        config = load_config(project_root=self._project_root())
+        assert config.ai.enabled is False
+        assert config.ai.max_tokens == 1500
         assert isinstance(config.ai, AIConfig)
         assert isinstance(config.layers, LayersConfig)

--- a/tests/unit/test_codeguard_config.py
+++ b/tests/unit/test_codeguard_config.py
@@ -2,6 +2,7 @@
 Tests unitarios para configuración de CodeGuard.
 """
 
+from pathlib import Path
 
 import pytest
 
@@ -391,3 +392,38 @@ min_pylint_score: 5.0
         # Debe retornar una instancia válida (puede tener defaults o config del proyecto actual)
         assert isinstance(config, CodeGuardConfig)
         assert isinstance(config.ai, AIConfig)
+
+
+class TestLoadConfigFromProjectPyproject:
+    """Verifica que load_config() lee correctamente el pyproject.toml real del proyecto."""
+
+    def _project_root(self) -> Path:
+        return Path(__file__).parent.parent.parent
+
+    def test_carga_desde_pyproject_toml_real(self):
+        config = load_config(project_root=self._project_root())
+        assert isinstance(config, CodeGuardConfig)
+
+    def test_campos_basicos_leidos(self):
+        config = load_config(project_root=self._project_root())
+        assert config.min_pylint_score == 8.0
+        assert config.max_cyclomatic_complexity == 10
+        assert config.max_line_length == 100
+        assert config.max_function_lines == 20
+
+    def test_nuevos_campos_v04_leidos(self):
+        config = load_config(project_root=self._project_root())
+        assert config.min_dead_code_confidence == 60
+        assert config.min_maintainability_index == 20
+
+    def test_checks_leidos_desde_archivo(self):
+        config = load_config(project_root=self._project_root())
+        assert config.checks.dead_code is True
+        assert config.checks.maintainability is True
+        assert config.checks.spelling is True
+
+    def test_ai_leido_desde_archivo(self):
+        config = load_config(project_root=self._project_root())
+        assert config.ai.enabled is False
+        assert config.ai.explain_errors is True
+        assert config.ai.max_tokens == 500

--- a/tests/unit/test_designreviewer_config.py
+++ b/tests/unit/test_designreviewer_config.py
@@ -4,6 +4,7 @@ Tests unitarios para DesignReviewerConfig y load_config().
 Ticket: 1.7
 """
 
+from pathlib import Path
 
 import pytest
 
@@ -262,3 +263,38 @@ max_line_length = 100
 
         assert isinstance(config, DesignReviewerConfig)
         assert isinstance(config.ai, AIConfig)
+
+
+class TestLoadConfigFromProjectPyproject:
+    """Verifica que load_config() lee correctamente el pyproject.toml real del proyecto."""
+
+    def _project_root(self) -> Path:
+        return Path(__file__).parent.parent.parent
+
+    def test_carga_desde_pyproject_toml_real(self):
+        config = load_config(project_root=self._project_root())
+        assert isinstance(config, DesignReviewerConfig)
+
+    def test_campos_basicos_leidos(self):
+        config = load_config(project_root=self._project_root())
+        assert config.max_cbo == 5
+        assert config.max_fan_out == 7
+        assert config.max_wmc == 20
+        assert config.max_method_lines == 20
+
+    def test_nuevos_campos_v04_leidos(self):
+        config = load_config(project_root=self._project_root())
+        assert config.max_demeter_depth == 1
+        assert config.max_primitive_params == 3
+
+    def test_checks_leidos_desde_archivo(self):
+        config = load_config(project_root=self._project_root())
+        assert config.checks.law_of_demeter is True
+        assert config.checks.primitive_obsession is True
+        assert config.checks.data_clumps is True
+
+    def test_ai_leido_desde_archivo(self):
+        config = load_config(project_root=self._project_root())
+        assert config.ai.enabled is False
+        assert config.ai.suggest_refactoring is True
+        assert config.ai.max_tokens == 800


### PR DESCRIPTION
## Resumen

Agrega las secciones de configuración de los tres agentes al `pyproject.toml` del proyecto, usando los valores actuales de los dataclasses como defaults explícitos documentados.

## Cambios

**`pyproject.toml`** — 3 secciones nuevas/expandidas:
- `[tool.codeguard]` + `[tool.codeguard.checks]` + `[tool.codeguard.ai]` (sección completamente nueva)
- `[tool.designreviewer]` expandido con 8 campos nuevos (incluyendo `max_demeter_depth`, `max_primitive_params`) + `[tool.designreviewer.checks]` completo
- `[tool.architectanalyst]` expandido con 6 campos nuevos (incluyendo `min_relational_cohesion`, `max_package_classes`, `min_coverage`, etc.) + `[tool.architectanalyst.checks]` completo

**Tests de integración** — 5 tests por agente (15 en total) que verifican:
- `load_config(project_root=project_root)` lee el `pyproject.toml` real sin errores
- Campos básicos, campos nuevos de v0.4.0, checks y ai son leídos correctamente

## Plan de tests

- [x] `pytest tests/unit/test_codeguard_config.py tests/unit/test_designreviewer_config.py tests/unit/test_architectanalyst_config.py` — 87 pasando
- [x] `ruff check` — sin errores

🤖 Generated with [Claude Code](https://claude.com/claude-code)